### PR TITLE
Add infrastructure and data domain foundations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Backend configuration
+KNOW_DATABASE_URL=postgresql+psycopg://postgres:postgres@postgres:5432/knowledge
+KNOW_JAEGER_HOST=jaeger
+KNOW_JAEGER_PORT=6831
+# Optional OTLP endpoint, e.g. http://otel-collector:4317
+KNOW_OTLP_ENDPOINT=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+postgres_data/
+backend/*.egg-info/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml setup.cfg /app/
+RUN pip install --upgrade pip \
+    && pip install .
+
+COPY app /app/app
+COPY alembic /app/alembic
+COPY alembic.ini /app/
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = postgresql+psycopg://postgres:postgres@postgres:5432/knowledge
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,60 @@
+"""Alembic configuration integrating SQLModel metadata."""
+"""Alembic environment configuration leveraging SQLModel metadata."""
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+from app.config import get_settings
+from app import models  # noqa: F401 - imported for side effects
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+
+def get_url() -> str:
+    override = config.get_main_option("sqlalchemy.url")
+    if override:
+        return override
+    return get_settings().database_url
+
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = get_url()
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        url=get_url(),
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/20240101_000001_initial.py
+++ b/backend/alembic/versions/20240101_000001_initial.py
@@ -1,0 +1,149 @@
+"""Initial schema for knowledge platform."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+# revision identifiers, used by Alembic.
+revision = "20240101_000001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    op.create_table(
+        "schemas",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("schema_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("description_vector", Vector(dim=1024), nullable=True),
+    )
+
+    op.create_table(
+        "artifacts",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False, server_default=""),
+        sa.Column("summary_vector", Vector(dim=1536), nullable=True),
+        sa.Column("parent_artifact_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("source_entry_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("applied_schema_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        sa.ForeignKeyConstraint(["parent_artifact_id"], ["artifacts.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["applied_schema_id"], ["schemas.id"], ondelete="SET NULL"),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("artifact_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("sender", sa.String(), nullable=True),
+        sa.Column("content_vector", Vector(dim=1536), nullable=True),
+        sa.ForeignKeyConstraint(["artifact_id"], ["artifacts.id"], ondelete="CASCADE"),
+    )
+
+    op.create_table(
+        "structured_entries",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("artifact_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("schema_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("data_json", sa.JSON(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("text_representation", sa.Text(), nullable=False),
+        sa.Column("text_representation_vector", Vector(dim=1536), nullable=True),
+        sa.ForeignKeyConstraint(["artifact_id"], ["artifacts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["schema_id"], ["schemas.id"], ondelete="SET NULL"),
+    )
+
+    op.create_foreign_key(
+        "fk_artifacts_source_entry",
+        "artifacts",
+        "structured_entries",
+        ["source_entry_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    op.create_table(
+        "links",
+        sa.Column("id", sa.String(), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("source_entity_type", sa.String(), nullable=False),
+        sa.Column("source_entity_id", sa.String(), nullable=False),
+        sa.Column("target_entity_type", sa.String(), nullable=False),
+        sa.Column("target_entity_id", sa.String(), nullable=False),
+        sa.Column("link_type", sa.String(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+
+    op.create_index("ix_artifacts_summary_vector", "artifacts", ["summary_vector"], postgresql_using="ivfflat")
+    op.create_index("ix_messages_content_vector", "messages", ["content_vector"], postgresql_using="ivfflat")
+    op.create_index(
+        "ix_structured_entries_text_vector",
+        "structured_entries",
+        ["text_representation_vector"],
+        postgresql_using="ivfflat",
+    )
+    op.create_index(
+        "ix_schemas_description_vector",
+        "schemas",
+        ["description_vector"],
+        postgresql_using="ivfflat",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_schemas_description_vector", table_name="schemas")
+    op.drop_index("ix_structured_entries_text_vector", table_name="structured_entries")
+    op.drop_index("ix_messages_content_vector", table_name="messages")
+    op.drop_index("ix_artifacts_summary_vector", table_name="artifacts")
+    op.drop_table("links")
+    op.drop_constraint("fk_artifacts_source_entry", "artifacts", type_="foreignkey")
+    op.drop_table("structured_entries")
+    op.drop_table("messages")
+    op.drop_table("artifacts")
+    op.drop_table("schemas")
+    op.execute("DROP EXTENSION IF EXISTS vector")

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Core backend package for the Knowledge platform."""

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,23 @@
+"""Configuration primitives for the backend service."""
+from functools import lru_cache
+from typing import Optional
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application level configuration sourced from environment variables."""
+
+    model_config = SettingsConfigDict(env_prefix="KNOW_", env_file=".env", env_file_encoding="utf-8")
+
+    database_url: str = (
+        "postgresql+psycopg://postgres:postgres@postgres:5432/knowledge"
+    )
+    otlp_endpoint: Optional[str] = None
+    jaeger_host: str = "jaeger"
+    jaeger_port: int = 6831
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,37 @@
+"""Database utilities for engine and session management."""
+from __future__ import annotations
+
+from typing import Tuple
+
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+
+def create_engine_and_session(*, url: str, echo: bool = False) -> Tuple[Engine, sessionmaker]:
+    """Create an engine and a session factory for the given URL.
+
+    SQLite is configured with an in-memory friendly setup for tests while
+    PostgreSQL benefits from connection pre-ping for long running sessions.
+    """
+
+    connect_args = {}
+    engine_kwargs = {"echo": echo, "future": True}
+    if url.startswith("sqlite"):  # pragma: no cover - deterministic branch
+        connect_args = {"check_same_thread": False}
+        engine_kwargs["poolclass"] = StaticPool
+    else:
+        engine_kwargs["pool_pre_ping"] = True
+
+    engine = create_engine(url, connect_args=connect_args, **engine_kwargs)
+    SQLModel.metadata.bind = engine
+    SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
+    return engine, SessionLocal
+
+
+# Provide a helper for production usage.
+def init_db(url: str) -> Session:
+    engine, SessionLocal = create_engine_and_session(url=url)
+    SQLModel.metadata.create_all(engine)
+    return SessionLocal()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,39 @@
+"""Entry point for the FastAPI backend service."""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from opentelemetry import trace
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from sqlmodel import SQLModel
+
+from .config import get_settings
+from .database import create_engine_and_session
+from .observability import configure_logging, configure_tracing
+
+
+def create_app() -> FastAPI:
+    settings = get_settings()
+    configure_logging()
+    configure_tracing(
+        service_name="live-knowledge-backend",
+        jaeger_host=settings.jaeger_host,
+        jaeger_port=settings.jaeger_port,
+        otlp_endpoint=settings.otlp_endpoint,
+    )
+
+    app = FastAPI(title="Live Knowledge Backend", version="0.1.0")
+    FastAPIInstrumentor.instrument_app(app, tracer_provider=trace.get_tracer_provider())
+
+    @app.get("/health", tags=["system"])
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.on_event("startup")
+    def _create_tables() -> None:
+        engine, _ = create_engine_and_session(url=settings.database_url)
+        SQLModel.metadata.create_all(engine)
+
+    return app
+
+
+app = create_app()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,207 @@
+"""Database models based on SQLModel for the knowledge platform."""
+
+from datetime import datetime
+from typing import List, Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import JSON, Column, DateTime, String, Text, BigInteger
+from sqlalchemy.sql import func
+from sqlalchemy.types import TypeDecorator
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Vector(TypeDecorator):
+    """Portable vector column.
+
+    Uses pgvector when running on PostgreSQL and falls back to JSON elsewhere,
+    which keeps tests light-weight while remaining production ready.
+    """
+
+    cache_ok = True
+    impl = JSON
+
+    def __init__(self, dim: Optional[int] = None) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def load_dialect_impl(self, dialect):  # type: ignore[override]
+        if dialect.name == "postgresql":
+            try:
+                from pgvector.sqlalchemy import Vector as PGVector
+            except ImportError as exc:  # pragma: no cover - defensive guard
+                raise RuntimeError(
+                    "pgvector must be installed to use vector columns on PostgreSQL"
+                ) from exc
+            return dialect.type_descriptor(PGVector(dim=self.dim))
+        return dialect.type_descriptor(JSON)
+
+    def process_bind_param(self, value, dialect):  # type: ignore[override]
+        if value is None:
+            return None
+        if isinstance(value, list):
+            return value
+        return list(value)
+
+    def process_result_value(self, value, dialect):  # type: ignore[override]
+        return value
+
+
+class Artifact(SQLModel, table=True):
+    __tablename__ = "artifacts"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+    title: str = Field(sa_column=Column(Text, nullable=False))
+    summary: str = Field(default="", sa_column=Column(Text, nullable=False))
+    summary_vector: Optional[List[float]] = Field(
+        default=None, sa_column=Column(Vector(dim=1536), nullable=True)
+    )
+    parent_artifact_id: Optional[UUID] = Field(default=None, foreign_key="artifacts.id")
+    source_entry_id: Optional[UUID] = Field(default=None, foreign_key="structured_entries.id")
+    applied_schema_id: Optional[UUID] = Field(default=None, foreign_key="schemas.id")
+
+    parent: Optional["Artifact"] = Relationship(
+        back_populates="children",
+        sa_relationship_kwargs={"remote_side": "Artifact.id"},
+    )
+    children: List["Artifact"] = Relationship(back_populates="parent")
+    messages: List["Message"] = Relationship(back_populates="artifact")
+    structured_entries: List["StructuredEntry"] = Relationship(
+        back_populates="artifact",
+        sa_relationship_kwargs={"foreign_keys": "StructuredEntry.artifact_id"},
+    )
+
+
+class Message(SQLModel, table=True):
+    __tablename__ = "messages"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+    artifact_id: UUID = Field(foreign_key="artifacts.id")
+    content: str = Field(sa_column=Column(Text, nullable=False))
+    sender: Optional[str] = Field(default=None, sa_column=Column(String, nullable=True))
+    content_vector: Optional[List[float]] = Field(
+        default=None, sa_column=Column(Vector(dim=1536), nullable=True)
+    )
+
+    artifact: "Artifact" = Relationship(back_populates="messages")
+
+
+class Schema(SQLModel, table=True):
+    __tablename__ = "schemas"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+    name: str = Field(sa_column=Column(String, nullable=False))
+    description: str = Field(default="", sa_column=Column(Text, nullable=False))
+    schema_json: dict = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))
+    description_vector: Optional[List[float]] = Field(
+        default=None, sa_column=Column(Vector(dim=1024), nullable=True)
+    )
+
+    structured_entries: List["StructuredEntry"] = Relationship(back_populates="schema")
+
+
+class StructuredEntry(SQLModel, table=True):
+    __tablename__ = "structured_entries"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+    artifact_id: UUID = Field(foreign_key="artifacts.id")
+    data_json: dict = Field(sa_column=Column(JSON, nullable=False))
+    text_representation: str = Field(sa_column=Column(Text, nullable=False))
+    text_representation_vector: Optional[List[float]] = Field(
+        default=None, sa_column=Column(Vector(dim=1536), nullable=True)
+    )
+
+    artifact: "Artifact" = Relationship(
+        back_populates="structured_entries",
+        sa_relationship_kwargs={"foreign_keys": "StructuredEntry.artifact_id"},
+    )
+    schema_id: Optional[UUID] = Field(default=None, foreign_key="schemas.id")
+    schema: Optional[Schema] = Relationship(back_populates="structured_entries")
+
+
+class Link(SQLModel, table=True):
+    __tablename__ = "links"
+
+    id: str = Field(
+        default_factory=lambda: str(uuid4()),
+        sa_column=Column(String, primary_key=True, nullable=False),
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(DateTime(timezone=True), server_default=func.now(), nullable=False),
+    )
+    updated_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        sa_column=Column(
+            DateTime(timezone=True),
+            server_default=func.now(),
+            onupdate=func.now(),
+            nullable=False,
+        ),
+    )
+    source_entity_type: str = Field(sa_column=Column(String, nullable=False))
+    source_entity_id: str = Field(sa_column=Column(String, nullable=False))
+    target_entity_type: str = Field(sa_column=Column(String, nullable=False))
+    target_entity_id: str = Field(sa_column=Column(String, nullable=False))
+    link_type: str = Field(sa_column=Column(String, nullable=False))
+    description: Optional[str] = Field(default=None, sa_column=Column(Text, nullable=True))
+
+
+__all__ = [
+    "Artifact",
+    "Message",
+    "Schema",
+    "StructuredEntry",
+    "Link",
+]

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -1,0 +1,62 @@
+"""Logging and tracing configuration helpers."""
+from __future__ import annotations
+
+import logging
+import logging.config
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+
+
+LOGGING_CONFIG = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "format": "%(asctime)s %(name)s %(levelname)s %(message)s",
+        }
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "json",
+            "level": "INFO",
+        }
+    },
+    "root": {"handlers": ["console"], "level": "INFO"},
+}
+
+
+def configure_logging() -> None:
+    """Configure structured logging for the service."""
+
+    logging.config.dictConfig(LOGGING_CONFIG)
+
+
+def configure_tracing(
+    *,
+    service_name: str,
+    jaeger_host: str,
+    jaeger_port: int,
+    otlp_endpoint: Optional[str] = None,
+) -> None:
+    """Configure OpenTelemetry tracing with Jaeger fallback."""
+
+    resource = Resource(attributes={SERVICE_NAME: service_name})
+    provider = TracerProvider(resource=resource)
+
+    if otlp_endpoint:
+        exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
+    else:
+        exporter = JaegerExporter(agent_host_name=jaeger_host, agent_port=jaeger_port)
+
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    # Always include console exporter for local debugging.
+    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(provider)

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -1,0 +1,162 @@
+"""Repository layer implementing CRUD operations for domain entities."""
+from __future__ import annotations
+
+from typing import List, Optional
+from uuid import UUID
+
+from sqlmodel import Session, select
+
+from .models import Artifact, Link, Schema, StructuredEntry
+
+
+class ArtifactRepository:
+    """Manage artifact persistence and hierarchy operations."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        title: str,
+        summary: str,
+        summary_vector: Optional[List[float]],
+        parent_artifact_id: Optional[UUID] = None,
+        source_entry_id: Optional[UUID] = None,
+        applied_schema_id: Optional[UUID] = None,
+    ) -> Artifact:
+        artifact = Artifact(
+            title=title,
+            summary=summary,
+            summary_vector=summary_vector,
+            parent_artifact_id=parent_artifact_id,
+            source_entry_id=source_entry_id,
+            applied_schema_id=applied_schema_id,
+        )
+        self.session.add(artifact)
+        self.session.commit()
+        self.session.refresh(artifact)
+        return artifact
+
+    def get(self, artifact_id: UUID) -> Optional[Artifact]:
+        statement = select(Artifact).where(Artifact.id == artifact_id)
+        return self.session.exec(statement).first()
+
+    def create_child(
+        self,
+        *,
+        parent: Artifact,
+        title: str,
+        summary: str,
+        summary_vector: Optional[List[float]],
+        source_entry_id: Optional[UUID] = None,
+        applied_schema_id: Optional[UUID] = None,
+    ) -> Artifact:
+        return self.create(
+            title=title,
+            summary=summary,
+            summary_vector=summary_vector,
+            parent_artifact_id=parent.id,
+            source_entry_id=source_entry_id,
+            applied_schema_id=applied_schema_id,
+        )
+
+
+class SchemaRepository:
+    """CRUD operations for schemas."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        name: str,
+        description: str,
+        schema_json: dict,
+        description_vector: Optional[List[float]],
+    ) -> Schema:
+        schema = Schema(
+            name=name,
+            description=description,
+            schema_json=schema_json,
+            description_vector=description_vector,
+        )
+        self.session.add(schema)
+        self.session.commit()
+        self.session.refresh(schema)
+        return schema
+
+    def get(self, schema_id: UUID) -> Optional[Schema]:
+        return self.session.get(Schema, schema_id)
+
+
+class StructuredEntryRepository:
+    """Access structured knowledge entries."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        artifact: Artifact,
+        data_json: dict,
+        text_representation: str,
+        vector: Optional[List[float]],
+        schema: Optional[Schema] = None,
+    ) -> StructuredEntry:
+        entry = StructuredEntry(
+            artifact_id=artifact.id,
+            data_json=data_json,
+            text_representation=text_representation,
+            text_representation_vector=vector,
+            schema_id=schema.id if schema else None,
+        )
+        self.session.add(entry)
+        self.session.commit()
+        self.session.refresh(entry)
+        return entry
+
+    def get(self, entry_id: UUID) -> Optional[StructuredEntry]:
+        return self.session.get(StructuredEntry, entry_id)
+
+
+class LinkRepository:
+    """Knowledge graph link operations."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        source_type: str,
+        source_id: UUID,
+        target_type: str,
+        target_id: UUID,
+        link_type: str,
+        description: Optional[str],
+    ) -> Link:
+        link = Link(
+            source_entity_type=source_type,
+            source_entity_id=str(source_id),
+            target_entity_type=target_type,
+            target_entity_id=str(target_id),
+            link_type=link_type,
+            description=description,
+        )
+        self.session.add(link)
+        self.session.commit()
+        self.session.refresh(link)
+        return link
+
+    def list_for_entity(self, *, entity_type: str, entity_id: UUID) -> List[Link]:
+        statement = select(Link).where(
+            (Link.source_entity_type == entity_type) & (Link.source_entity_id == str(entity_id))
+        )
+        return list(self.session.exec(statement))
+
+    def delete(self, link: Link) -> None:
+        self.session.delete(link)
+        self.session.commit()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "live-knowledge-backend"
+version = "0.1.0"
+description = "Backend services for the Live Knowledge platform"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.23",
+  "sqlmodel>=0.0.14",
+  "alembic>=1.12",
+  "pgvector>=0.2.4",
+  "psycopg[binary]>=3.1",
+  "python-dotenv>=1.0",
+  "pydantic-settings>=2.1",
+  "opentelemetry-sdk>=1.22",
+  "opentelemetry-instrumentation-fastapi>=0.46b0",
+  "opentelemetry-exporter-jaeger-thrift>=1.20",
+  "opentelemetry-exporter-otlp>=1.20",
+  "python-json-logger>=2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+  "pytest-asyncio>=0.23",
+  "ruff>=0.3",
+  "black>=23.12",
+  "mypy>=1.7",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["backend"]
+addopts = "-q"

--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,0 +1,25 @@
+[metadata]
+name = live-knowledge-backend
+version = 0.1.0
+
+[options]
+packages = find:
+package_dir = =.
+install_requires =
+    fastapi>=0.110
+    uvicorn[standard]>=0.23
+    sqlmodel>=0.0.14
+    alembic>=1.12
+    pgvector>=0.2.4
+    psycopg[binary]>=3.1
+    python-dotenv>=1.0
+    pydantic-settings>=2.1
+    opentelemetry-sdk>=1.22
+    opentelemetry-instrumentation-fastapi>=0.46b0
+    opentelemetry-exporter-jaeger-thrift>=1.20
+    opentelemetry-exporter-otlp>=1.20
+    python-json-logger>=2.0
+python_requires = >=3.11
+
+[options.packages.find]
+where = .

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -1,0 +1,91 @@
+import pytest
+from sqlmodel import Session
+
+from app.database import create_engine_and_session
+from app.models import Artifact, Link, Message, Schema, StructuredEntry
+from app.repositories import (
+    ArtifactRepository,
+    LinkRepository,
+    SchemaRepository,
+    StructuredEntryRepository,
+)
+
+
+@pytest.fixture()
+def session():
+    engine, SessionLocal = create_engine_and_session(url="sqlite://")
+    Artifact.metadata.create_all(engine)
+    Schema.metadata.create_all(engine)
+    Message.metadata.create_all(engine)
+    StructuredEntry.metadata.create_all(engine)
+    Link.metadata.create_all(engine)
+
+    with SessionLocal() as session:
+        yield session
+
+
+def test_artifact_hierarchy(session: Session):
+    repo = ArtifactRepository(session)
+
+    root = repo.create(title="Root", summary="", summary_vector=[0.1, 0.2])
+    child = repo.create_child(
+        parent=root,
+        title="Child",
+        summary="Child summary",
+        summary_vector=[0.2, 0.4],
+    )
+
+    fetched_root = repo.get(root.id)
+    assert fetched_root is not None
+    assert fetched_root.id == root.id
+    assert fetched_root.children[0].id == child.id
+    assert child.parent_artifact_id == root.id
+
+
+def test_structured_entry_schema_linkage(session: Session):
+    artifact_repo = ArtifactRepository(session)
+    schema_repo = SchemaRepository(session)
+    entry_repo = StructuredEntryRepository(session)
+
+    artifact = artifact_repo.create(title="Artifact", summary="", summary_vector=None)
+    schema = schema_repo.create(
+        name="Task Schema",
+        description="Tracks tasks",
+        schema_json={"Task": "string"},
+        description_vector=[0.1, 0.3],
+    )
+    artifact.applied_schema_id = schema.id
+    session.commit()
+
+    entry = entry_repo.create(
+        artifact=artifact,
+        data_json={"Task": "Ship"},
+        text_representation="Ship",
+        vector=[0.2, 0.5],
+    )
+
+    refreshed = entry_repo.get(entry.id)
+    assert refreshed is not None
+    assert refreshed.artifact_id == artifact.id
+    assert refreshed.schema is None  # no direct relation but ensures ORM fields exist
+    assert artifact.applied_schema_id == schema.id
+
+
+def test_link_repository(session: Session):
+    artifact_repo = ArtifactRepository(session)
+    link_repo = LinkRepository(session)
+
+    source = artifact_repo.create(title="Source", summary="", summary_vector=None)
+    target = artifact_repo.create(title="Target", summary="", summary_vector=None)
+
+    link = link_repo.create(
+        source_type="artifact",
+        source_id=source.id,
+        target_type="artifact",
+        target_id=target.id,
+        link_type="relates_to",
+        description="Related artifacts",
+    )
+
+    retrieved = link_repo.list_for_entity(entity_type="artifact", entity_id=source.id)
+    assert retrieved == [link]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: ankane/pgvector:latest
+    environment:
+      POSTGRES_DB: knowledge
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build:
+      context: ./backend
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    environment:
+      KNOW_DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/knowledge
+      KNOW_JAEGER_HOST: jaeger
+      KNOW_JAEGER_PORT: 6831
+    volumes:
+      - ./backend:/app
+      - ./.env:/app/.env:ro
+    ports:
+      - "8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      jaeger:
+        condition: service_started
+
+  frontend:
+    image: nginx:alpine
+    volumes:
+      - ./frontend:/usr/share/nginx/html:ro
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.53
+    ports:
+      - "16686:16686"
+      - "6831:6831/udp"
+
+volumes:
+  postgres_data:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Live Knowledge Frontend Placeholder</title>
+  </head>
+  <body>
+    <main>
+      <h1>Live Knowledge</h1>
+      <p>Frontend placeholder. Replace with SPA implementation.</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- set up docker-compose with pgvector Postgres, FastAPI backend, Jaeger tracing, and a static frontend placeholder plus env template
- scaffold the FastAPI backend with observability hooks, SQLModel data models, and repository layer aligned with the documented domain entities
- add Alembic migrations and repository tests covering artifact hierarchies, structured entries, and knowledge graph links

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd3aba087c8328a11cf88635acda97