### PR TITLE
Implement FastAPI stream D endpoints

### DIFF
--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,4 @@
+"""API package for FastAPI routers and related helpers."""
+
+from .routes import create_router  # noqa: F401
+from .session import SessionProvider  # noqa: F401

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -1,0 +1,143 @@
+"""API routers for the backend application."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
+from sqlmodel import Session
+
+from ..repositories import ArtifactRepository, LinkRepository, MessageRepository
+from .schemas import (
+    ArtifactChildSummary,
+    ArtifactDetailResponse,
+    ChatMessageRequest,
+    ChatMessageResponse,
+    LinkCreateRequest,
+    LinkResponse,
+    StructuredEntryResponse,
+)
+from .session import SessionProvider
+
+
+def _sorted_by_created(items: list[Any]) -> list[Any]:
+    return sorted(items, key=lambda item: getattr(item, "created_at", datetime.min))
+
+
+def create_router(session_provider: SessionProvider) -> APIRouter:
+    """Build an ``APIRouter`` wired with repository dependencies."""
+
+    router = APIRouter()
+
+    def get_session() -> Any:
+        yield from session_provider.dependency()
+
+    @router.post("/chat/message", response_model=ChatMessageResponse)
+    def post_chat_message(
+        payload: ChatMessageRequest,
+        session: Session = Depends(get_session),
+    ) -> ChatMessageResponse:
+        artifact_repo = ArtifactRepository(session)
+        message_repo = MessageRepository(session)
+
+        artifact = artifact_repo.get(payload.artifact_id)
+        if artifact is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
+
+        message = message_repo.create(
+            artifact=artifact,
+            content=payload.content,
+            sender=payload.sender,
+        )
+
+        return ChatMessageResponse.model_validate(message)
+
+    @router.get("/artifacts/{artifact_id}", response_model=ArtifactDetailResponse)
+    def get_artifact(
+        artifact_id: UUID,
+        session: Session = Depends(get_session),
+    ) -> ArtifactDetailResponse:
+        repo = ArtifactRepository(session)
+        artifact = repo.get_with_related(artifact_id)
+        if artifact is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
+
+        children = [ArtifactChildSummary.model_validate(child) for child in _sorted_by_created(list(artifact.children))]
+        messages = [ChatMessageResponse.model_validate(message) for message in _sorted_by_created(list(artifact.messages))]
+        structured_entries = [
+            StructuredEntryResponse.model_validate(entry)
+            for entry in _sorted_by_created(list(artifact.structured_entries))
+        ]
+
+        return ArtifactDetailResponse(
+            id=artifact.id,
+            title=artifact.title,
+            summary=artifact.summary,
+            parent_artifact_id=artifact.parent_artifact_id,
+            children=children,
+            messages=messages,
+            structured_entries=structured_entries,
+        )
+
+    @router.post(
+        "/artifacts/{artifact_id}/links",
+        status_code=status.HTTP_201_CREATED,
+        response_model=LinkResponse,
+    )
+    def create_link(
+        artifact_id: UUID,
+        payload: LinkCreateRequest,
+        session: Session = Depends(get_session),
+    ) -> LinkResponse:
+        artifact_repo = ArtifactRepository(session)
+        if artifact_repo.get(artifact_id) is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
+
+        link_repo = LinkRepository(session)
+        link = link_repo.create(
+            source_type="artifact",
+            source_id=artifact_id,
+            target_type=payload.target_entity_type,
+            target_id=UUID(payload.target_entity_id),
+            link_type=payload.link_type,
+            description=payload.description,
+        )
+
+        return LinkResponse.model_validate(link)
+
+    @router.websocket("/ws/chat/{artifact_id}")
+    async def websocket_chat(websocket: WebSocket, artifact_id: UUID) -> None:
+        await websocket.accept()
+
+        try:
+            while True:
+                payload = await websocket.receive_json()
+                content = payload.get("content")
+                sender = payload.get("sender")
+                if not content:
+                    await websocket.send_json({"error": "content_required"})
+                    continue
+
+                with session_provider.session_scope() as session:
+                    artifact_repo = ArtifactRepository(session)
+                    message_repo = MessageRepository(session)
+
+                    artifact = artifact_repo.get(artifact_id)
+                    if artifact is None:
+                        await websocket.send_json({"error": "artifact_not_found"})
+                        continue
+
+                    message = message_repo.create(
+                        artifact=artifact,
+                        content=str(content),
+                        sender=sender,
+                    )
+
+                encoded = ChatMessageResponse.model_validate(message).model_dump(mode="json")
+                await websocket.send_json(encoded)
+        except WebSocketDisconnect:
+            return
+
+    return router

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -1,0 +1,90 @@
+"""Pydantic schemas for the HTTP and WebSocket API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ChatMessageRequest(BaseModel):
+    """Incoming payload for creating a chat message."""
+
+    artifact_id: UUID
+    content: str
+    sender: Optional[str] = None
+
+
+class ChatMessageResponse(BaseModel):
+    """Representation of a chat message returned to clients."""
+
+    id: int
+    artifact_id: UUID
+    content: str
+    sender: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class StructuredEntryResponse(BaseModel):
+    """Structured entry embedded into artifact details."""
+
+    id: UUID
+    artifact_id: UUID
+    data_json: dict[str, Any]
+    text_representation: str
+    schema_id: Optional[UUID] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ArtifactChildSummary(BaseModel):
+    """Summary information about a child artifact."""
+
+    id: UUID
+    title: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ArtifactDetailResponse(BaseModel):
+    """Full artifact representation with nested resources."""
+
+    id: UUID
+    title: str
+    summary: str
+    parent_artifact_id: Optional[UUID] = None
+    children: list[ArtifactChildSummary]
+    messages: list[ChatMessageResponse]
+    structured_entries: list[StructuredEntryResponse]
+
+
+class LinkCreateRequest(BaseModel):
+    """Payload for creating a knowledge graph link."""
+
+    target_entity_type: str
+    target_entity_id: str
+    link_type: str
+    description: Optional[str] = None
+
+
+class LinkResponse(BaseModel):
+    """Representation of a knowledge graph link."""
+
+    id: str
+    source_entity_type: str
+    source_entity_id: str
+    target_entity_type: str
+    target_entity_id: str
+    link_type: str
+    description: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -1,0 +1,32 @@
+"""Helpers for working with database sessions in FastAPI dependencies."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import Session
+
+
+class SessionProvider:
+    """Wrap a ``sessionmaker`` to expose dependency-friendly interfaces."""
+
+    def __init__(self, session_factory: sessionmaker) -> None:
+        self._session_factory = session_factory
+
+    @contextmanager
+    def session_scope(self) -> Iterator[Session]:
+        """Context manager yielding a managed SQLModel session."""
+
+        session: Session = self._session_factory()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    def dependency(self) -> Iterator[Session]:
+        """FastAPI dependency that yields a session and ensures cleanup."""
+
+        with self.session_scope() as session:
+            yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,8 @@ from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from sqlmodel import SQLModel
 
+from .api.routes import create_router
+from .api.session import SessionProvider
 from .config import get_settings
 from .database import create_engine_and_session
 from .observability import configure_logging, configure_tracing
@@ -21,8 +23,16 @@ def create_app() -> FastAPI:
         otlp_endpoint=settings.otlp_endpoint,
     )
 
+    engine, session_factory = create_engine_and_session(url=settings.database_url)
+    session_provider = SessionProvider(session_factory)
+
     app = FastAPI(title="Live Knowledge Backend", version="0.1.0")
+    app.state.engine = engine
+    app.state.session_factory = session_factory
+    app.state.session_provider = session_provider
     FastAPIInstrumentor.instrument_app(app, tracer_provider=trace.get_tracer_provider())
+
+    app.include_router(create_router(session_provider))
 
     @app.get("/health", tags=["system"])
     async def health() -> dict[str, str]:
@@ -30,7 +40,6 @@ def create_app() -> FastAPI:
 
     @app.on_event("startup")
     def _create_tables() -> None:
-        engine, _ = create_engine_and_session(url=settings.database_url)
         SQLModel.metadata.create_all(engine)
 
     return app

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import logging.config
+import socket
 from typing import Optional
 
 from opentelemetry import trace
@@ -10,7 +11,14 @@ from opentelemetry.exporter.jaeger.thrift import JaegerExporter
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+)
+
+
+_TRACING_CONFIGURED = False
 
 
 LOGGING_CONFIG = {
@@ -48,15 +56,27 @@ def configure_tracing(
 ) -> None:
     """Configure OpenTelemetry tracing with Jaeger fallback."""
 
+    global _TRACING_CONFIGURED
+    if _TRACING_CONFIGURED:
+        return
+
     resource = Resource(attributes={SERVICE_NAME: service_name})
     provider = TracerProvider(resource=resource)
 
+    exporter = None
     if otlp_endpoint:
         exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
     else:
-        exporter = JaegerExporter(agent_host_name=jaeger_host, agent_port=jaeger_port)
+        try:
+            socket.gethostbyname(jaeger_host)
+        except OSError:
+            exporter = None
+        else:
+            exporter = JaegerExporter(agent_host_name=jaeger_host, agent_port=jaeger_port)
 
-    provider.add_span_processor(BatchSpanProcessor(exporter))
-    # Always include console exporter for local debugging.
-    provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    if exporter is not None:
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+    # Always include console exporter for local debugging without background threads.
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
     trace.set_tracer_provider(provider)
+    _TRACING_CONFIGURED = True

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from typing import List, Optional
 from uuid import UUID
 
+from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
-from .models import Artifact, Link, Schema, StructuredEntry
+from .models import Artifact, Link, Message, Schema, StructuredEntry
 
 
 class ArtifactRepository:
@@ -40,6 +41,18 @@ class ArtifactRepository:
 
     def get(self, artifact_id: UUID) -> Optional[Artifact]:
         statement = select(Artifact).where(Artifact.id == artifact_id)
+        return self.session.exec(statement).first()
+
+    def get_with_related(self, artifact_id: UUID) -> Optional[Artifact]:
+        statement = (
+            select(Artifact)
+            .where(Artifact.id == artifact_id)
+            .options(
+                selectinload(Artifact.children),
+                selectinload(Artifact.messages),
+                selectinload(Artifact.structured_entries),
+            )
+        )
         return self.session.exec(statement).first()
 
     def create_child(
@@ -120,6 +133,40 @@ class StructuredEntryRepository:
 
     def get(self, entry_id: UUID) -> Optional[StructuredEntry]:
         return self.session.get(StructuredEntry, entry_id)
+
+
+class MessageRepository:
+    """Persistence helpers for chat messages."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        artifact: Artifact,
+        content: str,
+        sender: Optional[str],
+        vector: Optional[List[float]] = None,
+    ) -> Message:
+        message = Message(
+            artifact_id=artifact.id,
+            content=content,
+            sender=sender,
+            content_vector=vector,
+        )
+        self.session.add(message)
+        self.session.commit()
+        self.session.refresh(message)
+        return message
+
+    def list_for_artifact(self, artifact_id: UUID) -> List[Message]:
+        statement = (
+            select(Message)
+            .where(Message.artifact_id == artifact_id)
+            .order_by(Message.created_at)
+        )
+        return list(self.session.exec(statement))
 
 
 class LinkRepository:

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,129 @@
+"""End-to-end tests for the FastAPI application (stream D)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import get_settings
+from app.main import create_app
+from app.repositories import (
+    ArtifactRepository,
+    MessageRepository,
+    StructuredEntryRepository,
+)
+
+
+@pytest.fixture()
+def app(monkeypatch: pytest.MonkeyPatch):
+    """Build an application instance backed by an in-memory database."""
+
+    get_settings.cache_clear()
+    monkeypatch.setenv("KNOW_DATABASE_URL", "sqlite://")
+    return create_app()
+
+
+@pytest.fixture()
+def client(app):
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture()
+def session_factory(app):
+    return app.state.session_factory
+
+
+@pytest.fixture()
+def artifact(session_factory) -> UUID:
+    with session_factory() as session:
+        repo = ArtifactRepository(session)
+        artifact = repo.create(title="Root", summary="", summary_vector=None)
+        return artifact.id
+
+
+def test_post_chat_message_creates_message(client, session_factory, artifact):
+    payload = {"artifact_id": str(artifact), "content": "Привет", "sender": "user"}
+
+    response = client.post("/chat/message", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["artifact_id"] == str(artifact)
+    assert body["content"] == "Привет"
+    assert body["sender"] == "user"
+
+    with session_factory() as session:
+        messages = MessageRepository(session).list_for_artifact(artifact_id=artifact)
+        assert len(messages) == 1
+        assert messages[0].content == "Привет"
+
+
+def test_get_artifact_returns_nested_payload(client, session_factory, artifact):
+    with session_factory() as session:
+        artifact_repo = ArtifactRepository(session)
+        entry_repo = StructuredEntryRepository(session)
+        message_repo = MessageRepository(session)
+
+        stored_artifact = artifact_repo.get(artifact)
+        assert stored_artifact is not None
+
+        message_repo.create(
+            artifact=stored_artifact,
+            content="Запланировать релиз",
+            sender="alice",
+        )
+
+        entry_repo.create(
+            artifact=stored_artifact,
+            data_json={"task": "Release"},
+            text_representation="task: Release",
+            vector=None,
+        )
+
+    response = client.get(f"/artifacts/{artifact}")
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["id"] == str(artifact)
+    assert body["messages"][0]["content"] == "Запланировать релиз"
+    assert body["structured_entries"][0]["data_json"] == {"task": "Release"}
+
+
+def test_post_artifact_link(client, session_factory, artifact):
+    with session_factory() as session:
+        target = ArtifactRepository(session).create(
+            title="Target", summary="", summary_vector=None
+        )
+        target_id = target.id
+
+    response = client.post(
+        f"/artifacts/{artifact}/links",
+        json={
+            "target_entity_type": "artifact",
+            "target_entity_id": str(target_id),
+            "link_type": "relates_to",
+            "description": "Связанные артефакты",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["source_entity_id"] == str(artifact)
+    assert data["target_entity_id"] == str(target_id)
+
+
+def test_websocket_chat_persists_messages(client, session_factory, artifact):
+    with client.websocket_connect(f"/ws/chat/{artifact}") as websocket:
+        websocket.send_json({"content": "Через WS", "sender": "bob"})
+        response = websocket.receive_json()
+
+    assert response["content"] == "Через WS"
+    assert response["artifact_id"] == str(artifact)
+
+    with session_factory() as session:
+        messages = MessageRepository(session).list_for_artifact(artifact_id=artifact)
+        assert len(messages) == 1
+        assert messages[0].sender == "bob"


### PR DESCRIPTION
## Summary
- add a FastAPI API package with routers, session helpers, and schemas covering chat message creation, artifact detail retrieval, link creation, and the chat websocket
- wire the new router into the application factory, extend repositories with message support, and tame observability so tracing configuration is idempotent and resilient without Jaeger
- introduce end-to-end API tests exercising the new HTTP and websocket endpoints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd3f2abec0832881d05235c21ea175