### PR TITLE
Integrate AI orchestrator into chat endpoint

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -3,20 +3,26 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Mapping
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
 from sqlmodel import Session
 
+from ..models import Message
 from ..repositories import ArtifactRepository, LinkRepository, MessageRepository
+from ..services.context_navigator import ContextResult, SearchHit
+from ..services.orchestrator import GenerationRequest, KnowledgeOrchestrator
 from .schemas import (
     ArtifactChildSummary,
     ArtifactDetailResponse,
     ChatMessageRequest,
     ChatMessageResponse,
+    ChatResponse,
+    ContextResponse,
     LinkCreateRequest,
     LinkResponse,
+    SearchHitResponse,
     StructuredEntryResponse,
 )
 from .session import SessionProvider
@@ -26,7 +32,7 @@ def _sorted_by_created(items: list[Any]) -> list[Any]:
     return sorted(items, key=lambda item: getattr(item, "created_at", datetime.min))
 
 
-def create_router(session_provider: SessionProvider) -> APIRouter:
+def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrchestrator) -> APIRouter:
     """Build an ``APIRouter`` wired with repository dependencies."""
 
     router = APIRouter()
@@ -34,11 +40,15 @@ def create_router(session_provider: SessionProvider) -> APIRouter:
     def get_session() -> Any:
         yield from session_provider.dependency()
 
-    @router.post("/chat/message", response_model=ChatMessageResponse)
-    def post_chat_message(
+    def get_orchestrator() -> KnowledgeOrchestrator:
+        return orchestrator
+
+    @router.post("/chat/message", response_model=ChatResponse)
+    async def post_chat_message(
         payload: ChatMessageRequest,
         session: Session = Depends(get_session),
-    ) -> ChatMessageResponse:
+        ai_orchestrator: KnowledgeOrchestrator = Depends(get_orchestrator),
+    ) -> ChatResponse:
         artifact_repo = ArtifactRepository(session)
         message_repo = MessageRepository(session)
 
@@ -46,13 +56,33 @@ def create_router(session_provider: SessionProvider) -> APIRouter:
         if artifact is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
 
-        message = message_repo.create(
+        history_messages = message_repo.list_for_artifact(artifact_id=artifact.id)
+        conversation_history = tuple(_message_to_prompt_dict(message) for message in history_messages)
+
+        user_message = message_repo.create(
             artifact=artifact,
             content=payload.content,
             sender=payload.sender,
         )
 
-        return ChatMessageResponse.model_validate(message)
+        generation = await ai_orchestrator.respond(
+            GenerationRequest(
+                user_message=user_message.content,
+                conversation_history=conversation_history,
+            )
+        )
+
+        assistant_message = message_repo.create(
+            artifact=artifact,
+            content=generation.content,
+            sender="assistant",
+        )
+
+        return ChatResponse(
+            user_message=ChatMessageResponse.model_validate(user_message),
+            assistant_message=ChatMessageResponse.model_validate(assistant_message),
+            context=_map_context_result(generation.context),
+        )
 
     @router.get("/artifacts/{artifact_id}", response_model=ArtifactDetailResponse)
     def get_artifact(
@@ -141,3 +171,28 @@ def create_router(session_provider: SessionProvider) -> APIRouter:
             return
 
     return router
+
+
+def _message_to_prompt_dict(message: Message) -> Mapping[str, str]:
+    sender = (message.sender or "user").lower()
+    if sender not in {"assistant", "system", "user"}:
+        sender = "user"
+    return {"role": sender, "content": message.content}
+
+
+def _map_context_result(result: ContextResult) -> ContextResponse:
+    return ContextResponse(
+        query=result.query,
+        artifacts=[_map_search_hit(hit) for hit in result.artifacts],
+        messages=[_map_search_hit(hit) for hit in result.messages],
+        structured_entries=[_map_search_hit(hit) for hit in result.structured_entries],
+    )
+
+
+def _map_search_hit(hit: SearchHit) -> SearchHitResponse:
+    payload: Mapping[str, Any]
+    if isinstance(hit.payload, Mapping):
+        payload = hit.payload
+    else:
+        payload = {}
+    return SearchHitResponse(id=hit.id, score=hit.score, payload=dict(payload))

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ChatMessageRequest(BaseModel):
@@ -42,6 +42,31 @@ class StructuredEntryResponse(BaseModel):
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SearchHitResponse(BaseModel):
+    """Serialized form of a context search result."""
+
+    id: str
+    score: float
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+class ContextResponse(BaseModel):
+    """Aggregated retrieval context returned with chat responses."""
+
+    query: str
+    artifacts: list[SearchHitResponse]
+    messages: list[SearchHitResponse]
+    structured_entries: list[SearchHitResponse]
+
+
+class ChatResponse(BaseModel):
+    """Full chat response including AI output and retrieval context."""
+
+    user_message: ChatMessageResponse
+    assistant_message: ChatMessageResponse
+    context: ContextResponse
 
 
 class ArtifactChildSummary(BaseModel):

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     jaeger_port: int = 6831
     vllm_embedding_base_url: str = "http://ai-embeddings:8000"
     vllm_chat_base_url: str = "http://ai-chat:8000"
+    vllm_embedding_model: str = "Qwen/Qwen3-Embedding-8B"
+    vllm_chat_model: str = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    context_top_k_artifacts: int = 5
+    context_top_k_messages: int = 5
+    context_top_k_structured: int = 5
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 """Entry point for the FastAPI backend service."""
 from __future__ import annotations
 
+from typing import Optional
+
 from fastapi import FastAPI
 from opentelemetry import trace
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -8,12 +10,15 @@ from sqlmodel import SQLModel
 
 from .api.routes import create_router
 from .api.session import SessionProvider
-from .config import get_settings
+from .ai.vllm import VLLMChatClient, VLLMEmbeddingClient
+from .config import Settings, get_settings
 from .database import create_engine_and_session
 from .observability import configure_logging, configure_tracing
+from .services import ContextNavigator, ContextNavigatorConfig, KnowledgeOrchestrator
+from .services.vector_index import NullVectorIndex
 
 
-def create_app() -> FastAPI:
+def create_app(*, orchestrator: Optional[KnowledgeOrchestrator] = None) -> FastAPI:
     settings = get_settings()
     configure_logging()
     configure_tracing(
@@ -25,14 +30,16 @@ def create_app() -> FastAPI:
 
     engine, session_factory = create_engine_and_session(url=settings.database_url)
     session_provider = SessionProvider(session_factory)
+    orchestrator_instance = orchestrator or _build_default_orchestrator(settings)
 
     app = FastAPI(title="Live Knowledge Backend", version="0.1.0")
     app.state.engine = engine
     app.state.session_factory = session_factory
     app.state.session_provider = session_provider
+    app.state.orchestrator = orchestrator_instance
     FastAPIInstrumentor.instrument_app(app, tracer_provider=trace.get_tracer_provider())
 
-    app.include_router(create_router(session_provider))
+    app.include_router(create_router(session_provider, orchestrator_instance))
 
     @app.get("/health", tags=["system"])
     async def health() -> dict[str, str]:
@@ -43,6 +50,30 @@ def create_app() -> FastAPI:
         SQLModel.metadata.create_all(engine)
 
     return app
+
+
+def _build_default_orchestrator(settings: Settings) -> KnowledgeOrchestrator:
+    embedding_client = VLLMEmbeddingClient(
+        base_url=settings.vllm_embedding_base_url,
+        model=settings.vllm_embedding_model,
+    )
+    chat_client = VLLMChatClient(
+        base_url=settings.vllm_chat_base_url,
+        model=settings.vllm_chat_model,
+    )
+    navigator = ContextNavigator(
+        embedding_client=embedding_client,
+        vector_index=NullVectorIndex(),
+        config=ContextNavigatorConfig(
+            artifact_namespace="artifacts",
+            message_namespace="messages",
+            structured_namespace="structured_entries",
+            top_k_artifacts=settings.context_top_k_artifacts,
+            top_k_messages=settings.context_top_k_messages,
+            top_k_structured=settings.context_top_k_structured,
+        ),
+    )
+    return KnowledgeOrchestrator(chat_client=chat_client, navigator=navigator)
 
 
 app = create_app()

--- a/backend/app/services/vector_index.py
+++ b/backend/app/services/vector_index.py
@@ -1,0 +1,22 @@
+"""Vector index implementations used by the AI services."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from .context_navigator import SearchHit, VectorIndex
+
+
+class NullVectorIndex(VectorIndex):
+    """Fallback vector index that returns no results.
+
+    This keeps the orchestration pipeline operational even when a real
+    similarity search backend is not yet configured.
+    """
+
+    async def search(
+        self, namespace: str, vector: Sequence[float], limit: int
+    ) -> Sequence[SearchHit]:
+        return []
+
+
+__all__ = ["NullVectorIndex"]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -9,6 +9,8 @@ from fastapi.testclient import TestClient
 
 from app.config import get_settings
 from app.main import create_app
+from app.services.context_navigator import ContextResult, SearchHit
+from app.services.orchestrator import GenerationRequest, GenerationResponse
 from app.repositories import (
     ArtifactRepository,
     MessageRepository,
@@ -16,13 +18,39 @@ from app.repositories import (
 )
 
 
+class FakeOrchestrator:
+    def __init__(self) -> None:
+        self.requests: list[GenerationRequest] = []
+
+    async def respond(self, request: GenerationRequest) -> GenerationResponse:
+        self.requests.append(request)
+        return GenerationResponse(
+            content="Ответ ассистента",
+            context=ContextResult(
+                query=request.user_message,
+                artifacts=[
+                    SearchHit(id="a1", score=0.9, payload={"title": "Artifact"}),
+                ],
+                messages=[SearchHit(id="m1", score=0.8, payload={"content": "Message"})],
+                structured_entries=[
+                    SearchHit(id="s1", score=0.7, payload={"text": "Structured"}),
+                ],
+            ),
+        )
+
+
 @pytest.fixture()
-def app(monkeypatch: pytest.MonkeyPatch):
+def fake_orchestrator() -> FakeOrchestrator:
+    return FakeOrchestrator()
+
+
+@pytest.fixture()
+def app(monkeypatch: pytest.MonkeyPatch, fake_orchestrator: FakeOrchestrator):
     """Build an application instance backed by an in-memory database."""
 
     get_settings.cache_clear()
     monkeypatch.setenv("KNOW_DATABASE_URL", "sqlite://")
-    return create_app()
+    return create_app(orchestrator=fake_orchestrator)
 
 
 @pytest.fixture()
@@ -44,21 +72,32 @@ def artifact(session_factory) -> UUID:
         return artifact.id
 
 
-def test_post_chat_message_creates_message(client, session_factory, artifact):
+def test_post_chat_message_triggers_ai_and_persists_messages(client, session_factory, artifact, fake_orchestrator):
     payload = {"artifact_id": str(artifact), "content": "Привет", "sender": "user"}
 
     response = client.post("/chat/message", json=payload)
 
     assert response.status_code == 200
     body = response.json()
-    assert body["artifact_id"] == str(artifact)
-    assert body["content"] == "Привет"
-    assert body["sender"] == "user"
+    assert body["user_message"]["artifact_id"] == str(artifact)
+    assert body["user_message"]["content"] == "Привет"
+    assert body["assistant_message"]["content"] == "Ответ ассистента"
+    assert body["assistant_message"]["sender"] == "assistant"
+    assert body["context"]["query"] == "Привет"
+    assert body["context"]["artifacts"][0]["id"] == "a1"
+
+    assert fake_orchestrator.requests
+    request = fake_orchestrator.requests[0]
+    assert request.user_message == "Привет"
+    assert list(request.conversation_history) == []
 
     with session_factory() as session:
         messages = MessageRepository(session).list_for_artifact(artifact_id=artifact)
-        assert len(messages) == 1
+        assert len(messages) == 2
         assert messages[0].content == "Привет"
+        assert messages[0].sender == "user"
+        assert messages[1].content == "Ответ ассистента"
+        assert messages[1].sender == "assistant"
 
 
 def test_get_artifact_returns_nested_payload(client, session_factory, artifact):

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -10,13 +10,28 @@ def test_vllm_service_base_urls_default(monkeypatch):
 
     assert settings.vllm_embedding_base_url == "http://ai-embeddings:8000"
     assert settings.vllm_chat_base_url == "http://ai-chat:8000"
+    assert settings.vllm_embedding_model == "Qwen/Qwen3-Embedding-8B"
+    assert settings.vllm_chat_model == "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+    assert settings.context_top_k_artifacts == 5
+    assert settings.context_top_k_messages == 5
+    assert settings.context_top_k_structured == 5
 
 
 def test_vllm_service_base_urls_override(monkeypatch):
     monkeypatch.setenv("KNOW_VLLM_EMBEDDING_BASE_URL", "http://localhost:9100")
     monkeypatch.setenv("KNOW_VLLM_CHAT_BASE_URL", "http://localhost:9200")
+    monkeypatch.setenv("KNOW_VLLM_EMBEDDING_MODEL", "local-embed")
+    monkeypatch.setenv("KNOW_VLLM_CHAT_MODEL", "local-chat")
+    monkeypatch.setenv("KNOW_CONTEXT_TOP_K_ARTIFACTS", "3")
+    monkeypatch.setenv("KNOW_CONTEXT_TOP_K_MESSAGES", "4")
+    monkeypatch.setenv("KNOW_CONTEXT_TOP_K_STRUCTURED", "2")
 
     settings = Settings(_env_file=None)
 
     assert settings.vllm_embedding_base_url == "http://localhost:9100"
     assert settings.vllm_chat_base_url == "http://localhost:9200"
+    assert settings.vllm_embedding_model == "local-embed"
+    assert settings.vllm_chat_model == "local-chat"
+    assert settings.context_top_k_artifacts == 3
+    assert settings.context_top_k_messages == 4
+    assert settings.context_top_k_structured == 2


### PR DESCRIPTION
## Summary
- connect the chat message endpoint to the `KnowledgeOrchestrator`, persist the assistant reply, and return retrieval context metadata
- add response schemas plus configuration knobs for model names and context limits, wiring them into the FastAPI app with a fallback vector index
- extend backend tests to cover the AI response flow and the new settings defaults

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd42c4bb3c8328a8cd599b78fd09e5