### PR TITLE
Connect frontend workspace views to backend APIs

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,100 @@
+import { API_BASE_URL } from '../config';
+
+export type ChatMessageRequest = {
+  artifact_id: string;
+  content: string;
+  sender?: string;
+};
+
+export type ChatMessageResponse = {
+  id: number;
+  artifact_id: string;
+  content: string;
+  sender?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ArtifactChildSummary = {
+  id: string;
+  title: string;
+};
+
+export type StructuredEntryResponse = {
+  id: string;
+  artifact_id: string;
+  data_json: Record<string, unknown>;
+  text_representation: string;
+  schema_id?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ArtifactDetailResponse = {
+  id: string;
+  title: string;
+  summary: string;
+  parent_artifact_id: string | null;
+  children: ArtifactChildSummary[];
+  messages: ChatMessageResponse[];
+  structured_entries: StructuredEntryResponse[];
+};
+
+export type LinkCreateRequest = {
+  target_entity_type: string;
+  target_entity_id: string;
+  link_type: string;
+  description?: string;
+};
+
+export type LinkResponse = {
+  id: string;
+  source_entity_type: string;
+  source_entity_id: string;
+  target_entity_type: string;
+  target_entity_id: string;
+  link_type: string;
+  description?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+const withJsonDefaults = (init: RequestInit = {}): RequestInit => ({
+  ...init,
+  headers: {
+    'Content-Type': 'application/json',
+    ...(init.headers ?? {}),
+  },
+});
+
+const parseResponse = async (response: Response) => {
+  const contentType = response.headers.get('content-type');
+  if (contentType && contentType.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+};
+
+const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(`${API_BASE_URL}${path}`, init);
+  const data = await parseResponse(response);
+
+  if (!response.ok) {
+    const detail = typeof data === 'object' && data !== null ? (data as { detail?: string }).detail : undefined;
+    throw new Error(detail ?? response.statusText ?? 'Request failed');
+  }
+
+  return data as T;
+};
+
+export const apiClient = {
+  getArtifactDetail: (artifactId: string) =>
+    request<ArtifactDetailResponse>(`/artifacts/${artifactId}`),
+  postChatMessage: (payload: ChatMessageRequest) =>
+    request<ChatMessageResponse>('/chat/message', withJsonDefaults({ method: 'POST', body: JSON.stringify(payload) })),
+  createLink: (artifactId: string, payload: LinkCreateRequest) =>
+    request<LinkResponse>(
+      `/artifacts/${artifactId}/links`,
+      withJsonDefaults({ method: 'POST', body: JSON.stringify(payload) }),
+    ),
+};

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,4 @@
+const env = import.meta.env;
+
+export const API_BASE_URL = env.VITE_API_BASE_URL ?? '';
+export const DEFAULT_ARTIFACT_ID = env.VITE_DEFAULT_ARTIFACT_ID ?? '';

--- a/frontend/src/pages/ArtifactChat.test.tsx
+++ b/frontend/src/pages/ArtifactChat.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '../providers/AppProviders';
+import { useWorkspaceStore } from '../store/workspaceStore';
+import { ArtifactChat } from './ArtifactChat';
+
+const renderChat = () =>
+  render(
+    <AppProviders>
+      <ArtifactChat />
+    </AppProviders>,
+  );
+
+const initialState = useWorkspaceStore.getState();
+
+beforeEach(() => {
+  useWorkspaceStore.setState(initialState, true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  useWorkspaceStore.setState(initialState, true);
+});
+
+describe('ArtifactChat', () => {
+  it('renders existing messages from the artifact thread', () => {
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      artifact: {
+        id: 'artifact-1',
+        title: 'Root artifact',
+        summary: 'Summary',
+        parent_artifact_id: null,
+        children: [],
+        structured_entries: [],
+        messages: [
+          {
+            id: 1,
+            artifact_id: 'artifact-1',
+            content: 'How do we plan the release?',
+            sender: 'user',
+            created_at: '2024-03-01T12:00:00Z',
+            updated_at: '2024-03-01T12:00:00Z',
+          },
+        ],
+      },
+    });
+
+    renderChat();
+
+    expect(screen.getByText('How do we plan the release?')).toBeInTheDocument();
+  });
+
+  it('submits a new message via the store action', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      sendMessage,
+      artifact: {
+        id: 'artifact-1',
+        title: 'Root artifact',
+        summary: 'Summary',
+        parent_artifact_id: null,
+        children: [],
+        structured_entries: [],
+        messages: [],
+      },
+    });
+
+    renderChat();
+
+    fireEvent.change(screen.getByPlaceholderText(/Share an update/i), {
+      target: { value: 'New message' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Send message/i }));
+
+    await waitFor(() =>
+      expect(sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'New message' }),
+      ),
+    );
+    expect(screen.getByPlaceholderText(/Share an update/i)).toHaveValue('');
+  });
+});

--- a/frontend/src/pages/ArtifactChat.tsx
+++ b/frontend/src/pages/ArtifactChat.tsx
@@ -1,10 +1,38 @@
-import { Button, Group, Paper, Stack, Text, Textarea, Title } from '@mantine/core';
-import { useState } from 'react';
+import { Alert, Button, Group, Loader, Paper, Stack, Text, Textarea, Title } from '@mantine/core';
+import { FormEvent, useState } from 'react';
+import { useArtifactData } from '../store/hooks';
 import { useWorkspaceStore } from '../store/workspaceStore';
 
 export const ArtifactChat = () => {
+  const { artifact, status, error } = useArtifactData();
+  const sendMessage = useWorkspaceStore((state) => state.sendMessage);
   const [message, setMessage] = useState('');
-  const thread = useWorkspaceStore((state) => state.activeThread);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const thread = artifact?.messages ?? [];
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      await sendMessage({ content: trimmed, sender: 'user' });
+      setMessage('');
+    } catch (submitException) {
+      const messageText =
+        submitException instanceof Error ? submitException.message : 'Failed to send message';
+      setSubmitError(messageText);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isLoading = status === 'loading' || status === 'idle';
 
   return (
     <Stack gap="lg">
@@ -12,29 +40,60 @@ export const ArtifactChat = () => {
         <Title order={2}>Artifact conversation</Title>
         <Text c="dimmed">Discuss insights with collaborators and AI assistants.</Text>
       </div>
+
+      {status === 'error' && error && (
+        <Alert color="red" title="Failed to load artifact thread">
+          {error}
+        </Alert>
+      )}
+
+      {isLoading && (
+        <Group justify="center">
+          <Loader />
+        </Group>
+      )}
+
+      {!isLoading && thread.length === 0 && (
+        <Text c="dimmed">No messages yet. Start the conversation below.</Text>
+      )}
+
       <Stack gap="sm">
         {thread.map((entry) => (
-          <Paper key={entry.id} p="sm" shadow="xs" radius="md" bg={entry.role === 'user' ? 'blue.0' : 'grape.0'}>
+          <Paper
+            key={entry.id}
+            p="sm"
+            shadow="xs"
+            radius="md"
+            bg={entry.sender ? 'blue.0' : 'grape.0'}
+          >
             <Stack gap={4}>
-              <Text fw={600}>{entry.role === 'user' ? 'You' : 'Assistant'}</Text>
+              <Text fw={600}>{entry.sender ? entry.sender : 'Assistant'}</Text>
               <Text>{entry.content}</Text>
             </Stack>
           </Paper>
         ))}
       </Stack>
-      <Stack gap="xs">
-        <Textarea
-          placeholder="Share an update or ask the AI"
-          minRows={3}
-          value={message}
-          onChange={(event) => setMessage(event.currentTarget.value)}
-        />
-        <Group justify="flex-end">
-          <Button disabled={!message.trim()} onClick={() => setMessage('')}>
-            Send message
-          </Button>
-        </Group>
-      </Stack>
+
+      <form onSubmit={handleSubmit}>
+        <Stack gap="xs">
+          <Textarea
+            placeholder="Share an update or ask the AI"
+            minRows={3}
+            value={message}
+            onChange={(event) => setMessage(event.currentTarget.value)}
+          />
+          {submitError && (
+            <Alert color="red" title="Unable to send message">
+              {submitError}
+            </Alert>
+          )}
+          <Group justify="flex-end">
+            <Button type="submit" disabled={!message.trim()} loading={isSubmitting}>
+              Send message
+            </Button>
+          </Group>
+        </Stack>
+      </form>
     </Stack>
   );
 };

--- a/frontend/src/pages/ArtifactsDashboard.test.tsx
+++ b/frontend/src/pages/ArtifactsDashboard.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '../providers/AppProviders';
+import { useWorkspaceStore } from '../store/workspaceStore';
+import { ArtifactsDashboard } from './ArtifactsDashboard';
+
+const renderDashboard = () =>
+  render(
+    <AppProviders>
+      <ArtifactsDashboard />
+    </AppProviders>,
+  );
+
+const initialState = useWorkspaceStore.getState();
+
+beforeEach(() => {
+  useWorkspaceStore.setState(initialState, true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  useWorkspaceStore.setState(initialState, true);
+});
+
+describe('ArtifactsDashboard', () => {
+  it('requests data for the current artifact when missing', () => {
+    const loadArtifact = vi.fn();
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'idle',
+      loadArtifact,
+    });
+
+    renderDashboard();
+
+    expect(loadArtifact).toHaveBeenCalledWith('artifact-1');
+  });
+
+  it('renders artifact summary, children and structured entries', () => {
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      artifact: {
+        id: 'artifact-1',
+        title: 'Root artifact',
+        summary: 'Artifact summary',
+        parent_artifact_id: null,
+        children: [
+          { id: 'artifact-2', title: 'Child artifact' },
+        ],
+        messages: [],
+        structured_entries: [
+          {
+            id: 'entry-1',
+            artifact_id: 'artifact-1',
+            text_representation: 'task: Plan release',
+            data_json: { task: 'Plan release' },
+            schema_id: null,
+            created_at: '2024-03-01T12:00:00Z',
+            updated_at: '2024-03-01T12:00:00Z',
+          },
+        ],
+      },
+    });
+
+    renderDashboard();
+
+    expect(screen.getByText('Artifact summary')).toBeInTheDocument();
+    expect(screen.getByText('Child artifact')).toBeInTheDocument();
+    expect(screen.getByText('task: Plan release')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/ArtifactsDashboard.tsx
+++ b/frontend/src/pages/ArtifactsDashboard.tsx
@@ -1,8 +1,24 @@
-import { Badge, Card, Group, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Card, Group, Loader, Stack, Text, TextInput, Title } from '@mantine/core';
+import { FormEvent, useEffect, useState } from 'react';
+import { useArtifactData } from '../store/hooks';
 import { useWorkspaceStore } from '../store/workspaceStore';
 
 export const ArtifactsDashboard = () => {
-  const recentArtifacts = useWorkspaceStore((state) => state.recentArtifacts);
+  const { artifact, status, error, currentArtifactId } = useArtifactData();
+  const loadArtifact = useWorkspaceStore((state) => state.loadArtifact);
+  const [artifactIdInput, setArtifactIdInput] = useState(currentArtifactId ?? '');
+
+  useEffect(() => {
+    setArtifactIdInput(currentArtifactId ?? '');
+  }, [currentArtifactId]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = artifactIdInput.trim();
+    if (trimmed) {
+      void loadArtifact(trimmed);
+    }
+  };
 
   return (
     <Stack gap="lg">
@@ -10,21 +26,100 @@ export const ArtifactsDashboard = () => {
         <Title order={2}>Artifacts overview</Title>
         <Text c="dimmed">Track the latest knowledge contributions and summaries.</Text>
       </div>
-      <Group align="stretch">
-        {recentArtifacts.map((artifact) => (
-          <Card key={artifact.id} shadow="sm" padding="lg" radius="md" withBorder miw={240}>
+
+      <form onSubmit={handleSubmit}>
+        <Group align="flex-end" gap="md">
+          <TextInput
+            label="Artifact ID"
+            placeholder="Enter an artifact UUID"
+            value={artifactIdInput}
+            onChange={(event) => setArtifactIdInput(event.currentTarget.value)}
+            style={{ flex: 1 }}
+          />
+          <Button type="submit" loading={status === 'loading'}>
+            Load artifact
+          </Button>
+        </Group>
+      </form>
+
+      {status === 'loading' && (
+        <Group justify="center">
+          <Loader />
+        </Group>
+      )}
+
+      {status === 'error' && error && (
+        <Alert color="red" title="Failed to load artifact">
+          {error}
+        </Alert>
+      )}
+
+      {status === 'success' && artifact && (
+        <Stack gap="lg">
+          <Card withBorder padding="lg" radius="md">
             <Stack gap="xs">
-              <Group justify="space-between">
-                <Title order={4}>{artifact.title}</Title>
-                <Badge color={artifact.status === 'draft' ? 'yellow' : 'green'}>{artifact.status}</Badge>
-              </Group>
-              <Text size="sm" c="dimmed">
-                {artifact.summary}
-              </Text>
+              <Title order={3}>{artifact.title}</Title>
+              <Text c="dimmed">{artifact.summary || 'No summary available yet.'}</Text>
             </Stack>
           </Card>
-        ))}
-      </Group>
+
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
+              <Group justify="space-between">
+                <Title order={4}>Structured entries</Title>
+                <Text size="sm" c="dimmed">
+                  {artifact.structured_entries.length} total
+                </Text>
+              </Group>
+              <Stack gap="xs">
+                {artifact.structured_entries.length === 0 && (
+                  <Text size="sm" c="dimmed">
+                    No structured entries available for this artifact.
+                  </Text>
+                )}
+                {artifact.structured_entries.map((entry) => (
+                  <Card key={entry.id} withBorder padding="md" radius="md">
+                    <Stack gap={4}>
+                      <Text>{entry.text_representation}</Text>
+                      {entry.schema_id && (
+                        <Text size="xs" c="dimmed">
+                          Schema: {entry.schema_id}
+                        </Text>
+                      )}
+                    </Stack>
+                  </Card>
+                ))}
+              </Stack>
+            </Stack>
+          </Card>
+
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
+              <Group justify="space-between">
+                <Title order={4}>Child artifacts</Title>
+                <Text size="sm" c="dimmed">
+                  {artifact.children.length} total
+                </Text>
+              </Group>
+              <Stack gap="xs">
+                {artifact.children.length === 0 && (
+                  <Text size="sm" c="dimmed">
+                    No child artifacts linked yet.
+                  </Text>
+                )}
+                {artifact.children.map((child) => (
+                  <Card key={child.id} withBorder padding="md" radius="md">
+                    <Text fw={600}>{child.title}</Text>
+                    <Text size="xs" c="dimmed">
+                      {child.id}
+                    </Text>
+                  </Card>
+                ))}
+              </Stack>
+            </Stack>
+          </Card>
+        </Stack>
+      )}
     </Stack>
   );
 };

--- a/frontend/src/pages/KnowledgeGraphView.test.tsx
+++ b/frontend/src/pages/KnowledgeGraphView.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppProviders } from '../providers/AppProviders';
+import { useWorkspaceStore } from '../store/workspaceStore';
+import { KnowledgeGraphView } from './KnowledgeGraphView';
+
+const renderView = () =>
+  render(
+    <AppProviders>
+      <KnowledgeGraphView />
+    </AppProviders>,
+  );
+
+const initialState = useWorkspaceStore.getState();
+
+beforeEach(() => {
+  useWorkspaceStore.setState(initialState, true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  useWorkspaceStore.setState(initialState, true);
+});
+
+describe('KnowledgeGraphView', () => {
+  it('shows structured entries and existing links', () => {
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      artifact: {
+        id: 'artifact-1',
+        title: 'Root artifact',
+        summary: 'Summary',
+        parent_artifact_id: null,
+        children: [
+          { id: 'artifact-2', title: 'Child artifact' },
+        ],
+        messages: [],
+        structured_entries: [
+          {
+            id: 'entry-1',
+            artifact_id: 'artifact-1',
+            text_representation: 'Key insight',
+            data_json: {},
+            schema_id: null,
+            created_at: '2024-03-01T12:00:00Z',
+            updated_at: '2024-03-01T12:00:00Z',
+          },
+        ],
+      },
+      links: [
+        {
+          id: 'link-1',
+          source_entity_type: 'artifact',
+          source_entity_id: 'artifact-1',
+          target_entity_type: 'artifact',
+          target_entity_id: 'artifact-2',
+          link_type: 'relates_to',
+          description: 'Связанные артефакты',
+          created_at: '2024-03-01T12:00:00Z',
+          updated_at: '2024-03-01T12:00:00Z',
+        },
+      ],
+    });
+
+    renderView();
+
+    expect(screen.getByText('Child artifact')).toBeInTheDocument();
+    expect(screen.getByText('Key insight')).toBeInTheDocument();
+    expect(screen.getByText(/relates_to/i)).toBeInTheDocument();
+  });
+
+  it('submits a new link using the store action', async () => {
+    const createLink = vi.fn().mockResolvedValue({
+      id: 'link-2',
+      source_entity_type: 'artifact',
+      source_entity_id: 'artifact-1',
+      target_entity_type: 'artifact',
+      target_entity_id: 'artifact-3',
+      link_type: 'supports',
+      description: 'Supports release plan',
+      created_at: '2024-03-02T12:00:00Z',
+      updated_at: '2024-03-02T12:00:00Z',
+    });
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      artifact: {
+        id: 'artifact-1',
+        title: 'Root artifact',
+        summary: 'Summary',
+        parent_artifact_id: null,
+        children: [],
+        structured_entries: [],
+        messages: [],
+      },
+      links: [],
+      createLink,
+    });
+
+    renderView();
+
+    fireEvent.change(screen.getByLabelText(/Target entity type/i), {
+      target: { value: 'artifact' },
+    });
+    fireEvent.change(screen.getByLabelText(/Target entity ID/i), {
+      target: { value: 'artifact-3' },
+    });
+    fireEvent.change(screen.getByLabelText(/Link type/i), {
+      target: { value: 'supports' },
+    });
+    fireEvent.change(screen.getByLabelText(/Description/i), {
+      target: { value: 'Supports release plan' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Create link/i }));
+
+    await waitFor(() =>
+      expect(createLink).toHaveBeenCalledWith({
+        targetEntityType: 'artifact',
+        targetEntityId: 'artifact-3',
+        linkType: 'supports',
+        description: 'Supports release plan',
+      }),
+    );
+  });
+});

--- a/frontend/src/pages/KnowledgeGraphView.tsx
+++ b/frontend/src/pages/KnowledgeGraphView.tsx
@@ -1,8 +1,51 @@
-import { Card, Divider, Group, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Card, Divider, Group, Loader, Stack, Text, TextInput, Textarea, Title } from '@mantine/core';
+import { ChangeEvent, FormEvent, useState } from 'react';
+import { useArtifactData } from '../store/hooks';
 import { useWorkspaceStore } from '../store/workspaceStore';
 
 export const KnowledgeGraphView = () => {
-  const graph = useWorkspaceStore((state) => state.graphSnapshot);
+  const { artifact, status, error } = useArtifactData();
+  const links = useWorkspaceStore((state) => state.links);
+  const createLink = useWorkspaceStore((state) => state.createLink);
+  const [formState, setFormState] = useState({
+    targetEntityType: 'artifact',
+    targetEntityId: '',
+    linkType: '',
+    description: '',
+  });
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = (field: keyof typeof formState) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setFormState((state) => ({ ...state, [field]: event.target.value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formState.targetEntityType || !formState.targetEntityId || !formState.linkType) {
+      setFormError('All fields except description are required.');
+      return;
+    }
+    setIsSubmitting(true);
+    setFormError(null);
+    try {
+      await createLink({
+        targetEntityType: formState.targetEntityType,
+        targetEntityId: formState.targetEntityId,
+        linkType: formState.linkType,
+        description: formState.description || undefined,
+      });
+      setFormState({ targetEntityType: 'artifact', targetEntityId: '', linkType: '', description: '' });
+    } catch (submitException) {
+      const message =
+        submitException instanceof Error ? submitException.message : 'Failed to create link';
+      setFormError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isLoading = status === 'loading' || status === 'idle';
 
   return (
     <Stack gap="lg">
@@ -10,33 +53,135 @@ export const KnowledgeGraphView = () => {
         <Title order={2}>Knowledge graph</Title>
         <Text c="dimmed">Review how artifacts connect through schemas and links.</Text>
       </div>
-      <Card withBorder padding="lg" radius="md">
-        <Stack gap="sm">
-          {graph.map((node) => (
-            <Stack key={node.id} gap="xs">
+
+      {status === 'error' && error && (
+        <Alert color="red" title="Failed to load graph data">
+          {error}
+        </Alert>
+      )}
+
+      {isLoading && (
+        <Group justify="center">
+          <Loader />
+        </Group>
+      )}
+
+      {status === 'success' && artifact && (
+        <Stack gap="lg">
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
               <Group justify="space-between">
-                <Text fw={600}>{node.label}</Text>
+                <Title order={4}>Structured entries</Title>
                 <Text size="sm" c="dimmed">
-                  {node.kind}
+                  {artifact.structured_entries.length} total
                 </Text>
               </Group>
-              <Divider my="xs" />
-              <Stack gap={4}>
-                {node.links.length === 0 && (
+              <Stack gap="xs">
+                {artifact.structured_entries.length === 0 && (
                   <Text size="sm" c="dimmed">
-                    No outgoing links yet.
+                    No structured entries captured yet.
                   </Text>
                 )}
-                {node.links.map((link) => (
-                  <Text key={link.id} size="sm">
-                    ↳ {link.label} → {link.targetLabel}
-                  </Text>
+                {artifact.structured_entries.map((entry) => (
+                  <Card key={entry.id} withBorder padding="md" radius="md">
+                    <Text>{entry.text_representation}</Text>
+                  </Card>
                 ))}
               </Stack>
             </Stack>
-          ))}
+          </Card>
+
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
+              <Group justify="space-between">
+                <Title order={4}>Child artifacts</Title>
+                <Text size="sm" c="dimmed">
+                  {artifact.children.length} total
+                </Text>
+              </Group>
+              <Stack gap="xs">
+                {artifact.children.length === 0 && (
+                  <Text size="sm" c="dimmed">
+                    No child artifacts registered.
+                  </Text>
+                )}
+                {artifact.children.map((child) => (
+                  <Card key={child.id} withBorder padding="md" radius="md">
+                    <Text fw={600}>{child.title}</Text>
+                    <Text size="xs" c="dimmed">
+                      {child.id}
+                    </Text>
+                  </Card>
+                ))}
+              </Stack>
+            </Stack>
+          </Card>
+
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
+              <Group justify="space-between">
+                <Title order={4}>Knowledge links</Title>
+                <Text size="sm" c="dimmed">
+                  {links.length} total
+                </Text>
+              </Group>
+              <Stack gap={4}>
+                {links.length === 0 && (
+                  <Text size="sm" c="dimmed">
+                    No links have been created in this session.
+                  </Text>
+                )}
+                {links.map((link) => (
+                  <Text key={link.id} size="sm">
+                    ↳ {link.link_type} → {link.target_entity_id}
+                    {link.description ? ` — ${link.description}` : ''}
+                  </Text>
+                ))}
+              </Stack>
+              <Divider my="sm" />
+              <form onSubmit={handleSubmit}>
+                <Stack gap="sm">
+                  <TextInput
+                    label="Target entity type"
+                    placeholder="artifact, schema, entry"
+                    value={formState.targetEntityType}
+                    onChange={handleChange('targetEntityType')}
+                  />
+                  <TextInput
+                    label="Target entity ID"
+                    placeholder="Enter UUID"
+                    value={formState.targetEntityId}
+                    onChange={handleChange('targetEntityId')}
+                  />
+                  <TextInput
+                    label="Link type"
+                    placeholder="e.g. relates_to, derives_from"
+                    value={formState.linkType}
+                    onChange={handleChange('linkType')}
+                  />
+                  <Textarea
+                    label="Description"
+                    placeholder="Describe the relationship"
+                    minRows={2}
+                    value={formState.description}
+                    onChange={handleChange('description')}
+                  />
+                  {formError && (
+                    <Alert color="red" title="Unable to create link">
+                      {formError}
+                    </Alert>
+                  )}
+                  <Group justify="flex-end">
+                    <Button type="submit" loading={isSubmitting} disabled={isSubmitting}>
+                      Create link
+                    </Button>
+                  </Group>
+                </Stack>
+              </form>
+            </Stack>
+          </Card>
         </Stack>
-      </Card>
+      )}
     </Stack>
   );
 };

--- a/frontend/src/store/hooks.ts
+++ b/frontend/src/store/hooks.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useWorkspaceStore } from './workspaceStore';
+
+export const useArtifactData = () => {
+  const artifact = useWorkspaceStore((state) => state.artifact);
+  const status = useWorkspaceStore((state) => state.artifactStatus);
+  const error = useWorkspaceStore((state) => state.artifactError);
+  const currentArtifactId = useWorkspaceStore((state) => state.currentArtifactId);
+  const loadArtifact = useWorkspaceStore((state) => state.loadArtifact);
+
+  useEffect(() => {
+    if (!currentArtifactId) {
+      return;
+    }
+
+    if (status === 'idle') {
+      void loadArtifact(currentArtifactId);
+      return;
+    }
+
+    if (!artifact || artifact.id !== currentArtifactId) {
+      void loadArtifact(currentArtifactId);
+    }
+  }, [artifact, currentArtifactId, status, loadArtifact]);
+
+  return { artifact, status, error, currentArtifactId };
+};

--- a/frontend/src/store/workspaceStore.test.ts
+++ b/frontend/src/store/workspaceStore.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWorkspaceStore } from './workspaceStore';
+
+const initialState = useWorkspaceStore.getState();
+
+const mockFetch = (payload: unknown) => {
+  const response = {
+    ok: true,
+    headers: {
+      get: () => 'application/json',
+    },
+    json: async () => payload,
+  } as Partial<Response>;
+  const fetchMock = vi.fn().mockResolvedValue(response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+};
+
+beforeEach(() => {
+  useWorkspaceStore.setState(initialState, true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  useWorkspaceStore.setState(initialState, true);
+});
+
+const sampleArtifact = {
+  id: 'artifact-1',
+  title: 'Root artifact',
+  summary: 'Artifact summary',
+  parent_artifact_id: null,
+  children: [{ id: 'artifact-2', title: 'Child artifact' }],
+  messages: [],
+  structured_entries: [
+    {
+      id: 'entry-1',
+      artifact_id: 'artifact-1',
+      data_json: { task: 'Plan release' },
+      text_representation: 'task: Plan release',
+      schema_id: null,
+      created_at: '2024-03-01T12:00:00Z',
+      updated_at: '2024-03-01T12:00:00Z',
+    },
+  ],
+};
+
+describe('workspaceStore', () => {
+  it('loads artifact details from the backend', async () => {
+    const fetchMock = mockFetch(sampleArtifact);
+
+    await useWorkspaceStore.getState().loadArtifact('artifact-1');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/artifacts/artifact-1');
+    const state = useWorkspaceStore.getState();
+    expect(state.currentArtifactId).toBe('artifact-1');
+    expect(state.artifact?.title).toBe('Root artifact');
+    expect(state.artifactStatus).toBe('success');
+    expect(state.artifactError).toBeNull();
+  });
+
+  it('posts a chat message and appends it to the artifact thread', async () => {
+    const messagePayload = {
+      id: 1,
+      artifact_id: 'artifact-1',
+      content: 'Привет',
+      sender: 'alice',
+      created_at: '2024-03-01T13:00:00Z',
+      updated_at: '2024-03-01T13:00:00Z',
+    };
+    const fetchMock = mockFetch(messagePayload);
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      artifact: { ...sampleArtifact, messages: [] },
+    });
+
+    await useWorkspaceStore.getState().sendMessage({ content: 'Привет', sender: 'alice' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/chat/message',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          artifact_id: 'artifact-1',
+          content: 'Привет',
+          sender: 'alice',
+        }),
+      }),
+    );
+    const state = useWorkspaceStore.getState();
+    expect(state.artifact?.messages).toHaveLength(1);
+    expect(state.artifact?.messages[0].content).toBe('Привет');
+  });
+
+  it('creates a knowledge link through the API and stores it locally', async () => {
+    const linkPayload = {
+      id: 'link-1',
+      source_entity_type: 'artifact',
+      source_entity_id: 'artifact-1',
+      target_entity_type: 'artifact',
+      target_entity_id: 'artifact-2',
+      link_type: 'relates_to',
+      description: 'Связанные артефакты',
+      created_at: '2024-03-01T14:00:00Z',
+      updated_at: '2024-03-01T14:00:00Z',
+    };
+    const fetchMock = mockFetch(linkPayload);
+    useWorkspaceStore.setState({
+      currentArtifactId: 'artifact-1',
+      artifactStatus: 'success',
+      artifact: sampleArtifact,
+      links: [],
+    });
+
+    await useWorkspaceStore
+      .getState()
+      .createLink({
+        targetEntityId: 'artifact-2',
+        targetEntityType: 'artifact',
+        linkType: 'relates_to',
+        description: 'Связанные артефакты',
+      });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/artifacts/artifact-1/links',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_entity_id: 'artifact-2',
+          target_entity_type: 'artifact',
+          link_type: 'relates_to',
+          description: 'Связанные артефакты',
+        }),
+      }),
+    );
+    const state = useWorkspaceStore.getState();
+    expect(state.links).toHaveLength(1);
+    expect(state.links[0].id).toBe('link-1');
+  });
+});

--- a/frontend/src/store/workspaceStore.ts
+++ b/frontend/src/store/workspaceStore.ts
@@ -1,94 +1,111 @@
 import { create } from 'zustand';
-
-type Artifact = {
-  id: string;
-  title: string;
-  summary: string;
-  status: 'draft' | 'published';
-};
-
-type ThreadEntry = {
-  id: string;
-  role: 'user' | 'assistant';
-  content: string;
-};
-
-type GraphLink = {
-  id: string;
-  label: string;
-  targetId: string;
-  targetLabel: string;
-};
-
-type GraphNode = {
-  id: string;
-  label: string;
-  kind: 'artifact' | 'schema' | 'entry';
-  links: GraphLink[];
-};
+import { apiClient, ArtifactDetailResponse, ChatMessageResponse, LinkResponse } from '../api/client';
+import { DEFAULT_ARTIFACT_ID } from '../config';
 
 type ThemeMode = 'light' | 'dark';
+
+type ArtifactStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type SendMessageInput = {
+  content: string;
+  sender?: string;
+};
+
+type CreateLinkInput = {
+  targetEntityType: string;
+  targetEntityId: string;
+  linkType: string;
+  description?: string;
+};
 
 type WorkspaceState = {
   theme: ThemeMode;
   setTheme: (theme: ThemeMode) => void;
   toggleTheme: () => void;
-  recentArtifacts: Artifact[];
-  activeThread: ThreadEntry[];
-  graphSnapshot: GraphNode[];
+  currentArtifactId: string | null;
+  artifact: ArtifactDetailResponse | null;
+  artifactStatus: ArtifactStatus;
+  artifactError: string | null;
+  links: LinkResponse[];
+  loadArtifact: (artifactId: string) => Promise<void>;
+  sendMessage: (input: SendMessageInput) => Promise<ChatMessageResponse>;
+  createLink: (input: CreateLinkInput) => Promise<LinkResponse>;
+  resetLinks: () => void;
 };
 
-const initialState = {
-  theme: 'light' as ThemeMode,
-  recentArtifacts: [
-    {
-      id: 'a-1',
-      title: 'Onboarding flow',
-      summary: 'Tasks and insights for new contributors to Live Knowledge.',
-      status: 'published' as const,
-    },
-    {
-      id: 'a-2',
-      title: 'Vector search experiments',
-      summary: 'Notes about pgvector tuning and embedding strategies.',
-      status: 'draft' as const,
-    },
-  ],
-  activeThread: [
-    {
-      id: 'm-1',
-      role: 'user' as const,
-      content: 'How do we structure the schema for AI-generated entries?',
-    },
-    {
-      id: 'm-2',
-      role: 'assistant' as const,
-      content: 'Start with a flexible JSON schema and iterate with validations.',
-    },
-  ],
-  graphSnapshot: [
-    {
-      id: 'g-1',
-      label: 'Onboarding flow',
-      kind: 'artifact' as const,
-      links: [
-        { id: 'l-1', label: 'references', targetId: 'g-2', targetLabel: 'Contributor checklist' },
-      ],
-    },
-    {
-      id: 'g-2',
-      label: 'Contributor checklist',
-      kind: 'schema' as const,
-      links: [],
-    },
-  ],
-};
+const initialArtifactId = DEFAULT_ARTIFACT_ID || null;
 
-export const useWorkspaceStore = create<WorkspaceState>((set) => ({
-  ...initialState,
+export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
+  theme: 'light',
   setTheme: (theme) => set({ theme }),
   toggleTheme: () =>
     set((state) => ({
       theme: state.theme === 'light' ? 'dark' : 'light',
     })),
+  currentArtifactId: initialArtifactId,
+  artifact: null,
+  artifactStatus: 'idle',
+  artifactError: null,
+  links: [],
+  resetLinks: () => set({ links: [] }),
+  loadArtifact: async (artifactId: string) => {
+    if (!artifactId) {
+      set({
+        currentArtifactId: null,
+        artifact: null,
+        artifactStatus: 'idle',
+        artifactError: null,
+      });
+      return;
+    }
+
+    set({
+      currentArtifactId: artifactId,
+      artifactStatus: 'loading',
+      artifactError: null,
+      links: [],
+    });
+
+    try {
+      const artifact = await apiClient.getArtifactDetail(artifactId);
+      set({ artifact, artifactStatus: 'success', artifactError: null });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load artifact';
+      set({ artifact: null, artifactStatus: 'error', artifactError: message });
+    }
+  },
+  sendMessage: async ({ content, sender }: SendMessageInput) => {
+    const { currentArtifactId, artifact } = get();
+    if (!currentArtifactId) {
+      throw new Error('No artifact selected');
+    }
+    const payload = await apiClient.postChatMessage({
+      artifact_id: currentArtifactId,
+      content,
+      sender,
+    });
+    if (artifact) {
+      set({
+        artifact: {
+          ...artifact,
+          messages: [...artifact.messages, payload],
+        },
+      });
+    }
+    return payload;
+  },
+  createLink: async ({ targetEntityId, targetEntityType, linkType, description }: CreateLinkInput) => {
+    const { currentArtifactId } = get();
+    if (!currentArtifactId) {
+      throw new Error('No artifact selected');
+    }
+    const link = await apiClient.createLink(currentArtifactId, {
+      target_entity_id: targetEntityId,
+      target_entity_type: targetEntityType,
+      link_type: linkType,
+      description,
+    });
+    set((state) => ({ links: [...state.links, link] }));
+    return link;
+  },
 }));


### PR DESCRIPTION
## Summary
- replace the in-memory workspace store with backend-aware actions for loading artifacts, posting chat messages, and creating links
- add a shared API client, config helpers, and hooks so dashboard, chat, and graph pages render live data and expose submission forms
- cover the new flows with unit tests for the store and React pages to drive the implementation

## Testing
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68dd442911d883289c548b4f29324371