### PR TITLE
Ensure pgvector extension is created before table setup

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Tuple
 
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -30,8 +31,19 @@ def create_engine_and_session(*, url: str, echo: bool = False) -> Tuple[Engine, 
     return engine, SessionLocal
 
 
+def ensure_vector_extension(engine: Engine) -> None:
+    """Ensure the pgvector extension exists when using PostgreSQL."""
+
+    if engine.dialect.name != "postgresql":
+        return
+
+    with engine.connect() as connection:
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+
 # Provide a helper for production usage.
 def init_db(url: str) -> Session:
     engine, SessionLocal = create_engine_and_session(url=url)
+    ensure_vector_extension(engine)
     SQLModel.metadata.create_all(engine)
     return SessionLocal()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from .api.routes import create_router
 from .api.session import SessionProvider
 from .ai.vllm import VLLMChatClient, VLLMEmbeddingClient
 from .config import Settings, get_settings
-from .database import create_engine_and_session
+from .database import create_engine_and_session, ensure_vector_extension
 from .observability import configure_logging, configure_tracing
 from .services import ContextNavigator, ContextNavigatorConfig, KnowledgeOrchestrator
 from .services.vector_index import NullVectorIndex
@@ -47,6 +47,7 @@ def create_app(*, orchestrator: Optional[KnowledgeOrchestrator] = None) -> FastA
 
     @app.on_event("startup")
     def _create_tables() -> None:
+        ensure_vector_extension(engine)
         SQLModel.metadata.create_all(engine)
 
     return app

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,0 +1,39 @@
+"""Tests for database utilities."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.database import ensure_vector_extension
+
+
+def _build_engine_mock(dialect_name: str) -> MagicMock:
+    engine = MagicMock()
+    engine.dialect.name = dialect_name
+    connection = MagicMock()
+    context_manager = MagicMock()
+    context_manager.__enter__.return_value = connection
+    context_manager.__exit__.return_value = False
+    engine.connect.return_value = context_manager
+    return engine
+
+
+def test_ensure_vector_extension_executes_on_postgres() -> None:
+    engine = _build_engine_mock("postgresql")
+
+    ensure_vector_extension(engine)
+
+    connection = engine.connect.return_value.__enter__.return_value
+    execute_calls = connection.execute.call_args_list
+    assert execute_calls, "Expected CREATE EXTENSION to be executed"
+    executed_statement = str(execute_calls[0].args[0]).strip()
+    assert executed_statement == "CREATE EXTENSION IF NOT EXISTS vector"
+
+
+def test_ensure_vector_extension_is_noop_on_sqlite() -> None:
+    engine = _build_engine_mock("sqlite")
+
+    ensure_vector_extension(engine)
+
+    connection = engine.connect.return_value.__enter__.return_value
+    connection.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- add `ensure_vector_extension` helper to create the pgvector extension when using PostgreSQL
- invoke the helper during app startup and database initialization before creating tables
- cover the helper with tests for PostgreSQL and non-PostgreSQL engines

## Testing
- PYTHONPATH=backend pytest backend/tests/test_database.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd4b2e2d3883288255751c718a3873