### PR TITLE
Ensure pgvector extension creation uses autocommit

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -38,7 +37,8 @@ def ensure_vector_extension(engine: Engine) -> None:
         return
 
     with engine.connect() as connection:
-        connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        autocommit_connection = connection.execution_options(isolation_level="AUTOCOMMIT")
+        autocommit_connection.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS vector")
 
 
 # Provide a helper for production usage.

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -7,33 +7,34 @@ from unittest.mock import MagicMock
 from app.database import ensure_vector_extension
 
 
-def _build_engine_mock(dialect_name: str) -> MagicMock:
+def _build_engine_mock(dialect_name: str) -> tuple[MagicMock, MagicMock, MagicMock]:
     engine = MagicMock()
     engine.dialect.name = dialect_name
-    connection = MagicMock()
+    connection = MagicMock(name="connection")
+    autocommit_connection = MagicMock(name="autocommit_connection")
+    connection.execution_options.return_value = autocommit_connection
     context_manager = MagicMock()
     context_manager.__enter__.return_value = connection
     context_manager.__exit__.return_value = False
     engine.connect.return_value = context_manager
-    return engine
+    return engine, connection, autocommit_connection
 
 
 def test_ensure_vector_extension_executes_on_postgres() -> None:
-    engine = _build_engine_mock("postgresql")
+    engine, connection, autocommit_connection = _build_engine_mock("postgresql")
 
     ensure_vector_extension(engine)
 
-    connection = engine.connect.return_value.__enter__.return_value
-    execute_calls = connection.execute.call_args_list
-    assert execute_calls, "Expected CREATE EXTENSION to be executed"
-    executed_statement = str(execute_calls[0].args[0]).strip()
-    assert executed_statement == "CREATE EXTENSION IF NOT EXISTS vector"
+    connection.execution_options.assert_called_once_with(isolation_level="AUTOCOMMIT")
+    autocommit_connection.exec_driver_sql.assert_called_once_with(
+        "CREATE EXTENSION IF NOT EXISTS vector"
+    )
 
 
 def test_ensure_vector_extension_is_noop_on_sqlite() -> None:
-    engine = _build_engine_mock("sqlite")
+    engine, connection, autocommit_connection = _build_engine_mock("sqlite")
 
     ensure_vector_extension(engine)
 
-    connection = engine.connect.return_value.__enter__.return_value
-    connection.execute.assert_not_called()
+    connection.execution_options.assert_not_called()
+    autocommit_connection.exec_driver_sql.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure the pgvector extension is created using an autocommit connection
- update database utility tests to cover the autocommit behaviour

## Testing
- `PYTHONPATH=. poetry run pytest tests/test_database.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd4d85d4e48328a56d6bf66689acc0