### PR TITLE
Implement async vector infrastructure and embedding integration

### DIFF
--- a/backend/alembic/versions/20240101_000001_initial.py
+++ b/backend/alembic/versions/20240101_000001_initial.py
@@ -119,19 +119,53 @@ def upgrade() -> None:
         sa.Column("description", sa.Text(), nullable=True),
     )
 
-    op.create_index("ix_artifacts_summary_vector", "artifacts", ["summary_vector"], postgresql_using="ivfflat")
-    op.create_index("ix_messages_content_vector", "messages", ["content_vector"], postgresql_using="ivfflat")
+    op.create_index(
+        "ix_artifacts_summary_vector",
+        "artifacts",
+        ["summary_vector"],
+        postgresql_using="hnsw",
+        postgresql_with={"m": 16, "ef_construction": 64},
+    )
+    op.create_index(
+        "ix_messages_content_vector",
+        "messages",
+        ["content_vector"],
+        postgresql_using="hnsw",
+        postgresql_with={"m": 16, "ef_construction": 64},
+    )
     op.create_index(
         "ix_structured_entries_text_vector",
         "structured_entries",
         ["text_representation_vector"],
-        postgresql_using="ivfflat",
+        postgresql_using="hnsw",
+        postgresql_with={"m": 16, "ef_construction": 64},
     )
     op.create_index(
         "ix_schemas_description_vector",
         "schemas",
         ["description_vector"],
-        postgresql_using="ivfflat",
+        postgresql_using="hnsw",
+        postgresql_with={"m": 16, "ef_construction": 64},
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE PROCEDURE refresh_hnsw_indexes(m_value integer DEFAULT 16, ef_value integer DEFAULT 64)
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            ALTER INDEX IF EXISTS ix_artifacts_summary_vector SET (m = m_value, ef_construction = ef_value);
+            ALTER INDEX IF EXISTS ix_messages_content_vector SET (m = m_value, ef_construction = ef_value);
+            ALTER INDEX IF EXISTS ix_structured_entries_text_vector SET (m = m_value, ef_construction = ef_value);
+            ALTER INDEX IF EXISTS ix_schemas_description_vector SET (m = m_value, ef_construction = ef_value);
+
+            REINDEX TABLE artifacts;
+            REINDEX TABLE messages;
+            REINDEX TABLE structured_entries;
+            REINDEX TABLE schemas;
+        END;
+        $$;
+        """
     )
 
 
@@ -140,6 +174,7 @@ def downgrade() -> None:
     op.drop_index("ix_structured_entries_text_vector", table_name="structured_entries")
     op.drop_index("ix_messages_content_vector", table_name="messages")
     op.drop_index("ix_artifacts_summary_vector", table_name="artifacts")
+    op.execute("DROP PROCEDURE IF EXISTS refresh_hnsw_indexes")
     op.drop_table("links")
     op.drop_constraint("fk_artifacts_source_entry", "artifacts", type_="foreignkey")
     op.drop_table("structured_entries")

--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -1,0 +1,40 @@
+"""Shared FastAPI dependencies for repositories and infrastructure."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from fastapi import Depends, Request
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..services.vector_index import EmbeddingClient
+from .session import SessionProvider
+
+
+def get_session_provider(request: Request) -> SessionProvider:
+    provider = getattr(request.app.state, "session_provider", None)
+    if provider is None:
+        raise RuntimeError("Session provider is not configured")
+    return provider
+
+
+async def get_session(
+    provider: SessionProvider = Depends(get_session_provider),
+) -> AsyncIterator[AsyncSession]:
+    async with provider.session_scope() as session:
+        yield session
+
+
+def get_embedding_client(request: Request) -> EmbeddingClient:
+    client = getattr(request.app.state, "embedding_client", None)
+    if client is None:
+        raise RuntimeError("Embedding client is not configured")
+    return client
+
+
+def get_orchestrator(request: Request):
+    orchestrator = getattr(request.app.state, "orchestrator", None)
+    if orchestrator is None:
+        raise RuntimeError("Knowledge orchestrator is not configured")
+    return orchestrator

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -7,12 +7,14 @@ from typing import Any, Mapping
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect, status
-from sqlmodel import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..models import Message
 from ..repositories import ArtifactRepository, LinkRepository, MessageRepository
 from ..services.context_navigator import ContextResult, SearchHit
 from ..services.orchestrator import GenerationRequest, KnowledgeOrchestrator
+from ..services.vector_index import EmbeddingClient
+from .dependencies import get_embedding_client, get_orchestrator, get_session
 from .schemas import (
     ArtifactChildSummary,
     ArtifactDetailResponse,
@@ -37,29 +39,24 @@ def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrch
 
     router = APIRouter()
 
-    def get_session() -> Any:
-        yield from session_provider.dependency()
-
-    def get_orchestrator() -> KnowledgeOrchestrator:
-        return orchestrator
-
     @router.post("/chat/message", response_model=ChatResponse)
     async def post_chat_message(
         payload: ChatMessageRequest,
-        session: Session = Depends(get_session),
+        session: AsyncSession = Depends(get_session),
         ai_orchestrator: KnowledgeOrchestrator = Depends(get_orchestrator),
+        embedding_client: EmbeddingClient = Depends(get_embedding_client),
     ) -> ChatResponse:
-        artifact_repo = ArtifactRepository(session)
-        message_repo = MessageRepository(session)
+        artifact_repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+        message_repo = MessageRepository(session=session, embedding_client=embedding_client)
 
-        artifact = artifact_repo.get(payload.artifact_id)
+        artifact = await artifact_repo.get(payload.artifact_id)
         if artifact is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
 
-        history_messages = message_repo.list_for_artifact(artifact_id=artifact.id)
+        history_messages = await message_repo.list_for_artifact(artifact_id=artifact.id)
         conversation_history = tuple(_message_to_prompt_dict(message) for message in history_messages)
 
-        user_message = message_repo.create(
+        user_message = await message_repo.create(
             artifact=artifact,
             content=payload.content,
             sender=payload.sender,
@@ -72,7 +69,7 @@ def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrch
             )
         )
 
-        assistant_message = message_repo.create(
+        assistant_message = await message_repo.create(
             artifact=artifact,
             content=generation.content,
             sender="assistant",
@@ -85,12 +82,12 @@ def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrch
         )
 
     @router.get("/artifacts/{artifact_id}", response_model=ArtifactDetailResponse)
-    def get_artifact(
+    async def get_artifact(
         artifact_id: UUID,
-        session: Session = Depends(get_session),
+        session: AsyncSession = Depends(get_session),
     ) -> ArtifactDetailResponse:
-        repo = ArtifactRepository(session)
-        artifact = repo.get_with_related(artifact_id)
+        repo = ArtifactRepository(session=session)
+        artifact = await repo.get_with_related(artifact_id)
         if artifact is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
 
@@ -116,17 +113,17 @@ def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrch
         status_code=status.HTTP_201_CREATED,
         response_model=LinkResponse,
     )
-    def create_link(
+    async def create_link(
         artifact_id: UUID,
         payload: LinkCreateRequest,
-        session: Session = Depends(get_session),
+        session: AsyncSession = Depends(get_session),
     ) -> LinkResponse:
-        artifact_repo = ArtifactRepository(session)
-        if artifact_repo.get(artifact_id) is None:
+        artifact_repo = ArtifactRepository(session=session)
+        if await artifact_repo.get(artifact_id) is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
 
-        link_repo = LinkRepository(session)
-        link = link_repo.create(
+        link_repo = LinkRepository(session=session)
+        link = await link_repo.create(
             source_type="artifact",
             source_id=artifact_id,
             target_type=payload.target_entity_type,
@@ -138,7 +135,11 @@ def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrch
         return LinkResponse.model_validate(link)
 
     @router.websocket("/ws/chat/{artifact_id}")
-    async def websocket_chat(websocket: WebSocket, artifact_id: UUID) -> None:
+    async def websocket_chat(
+        websocket: WebSocket,
+        artifact_id: UUID,
+        embedding_client: EmbeddingClient = Depends(get_embedding_client),
+    ) -> None:
         await websocket.accept()
 
         try:
@@ -150,16 +151,16 @@ def create_router(session_provider: SessionProvider, orchestrator: KnowledgeOrch
                     await websocket.send_json({"error": "content_required"})
                     continue
 
-                with session_provider.session_scope() as session:
-                    artifact_repo = ArtifactRepository(session)
-                    message_repo = MessageRepository(session)
+                async with session_provider.session_scope() as session:
+                    artifact_repo = ArtifactRepository(session=session)
+                    message_repo = MessageRepository(session=session, embedding_client=embedding_client)
 
-                    artifact = artifact_repo.get(artifact_id)
+                    artifact = await artifact_repo.get(artifact_id)
                     if artifact is None:
                         await websocket.send_json({"error": "artifact_not_found"})
                         continue
 
-                    message = message_repo.create(
+                    message = await message_repo.create(
                         artifact=artifact,
                         content=str(content),
                         sender=sender,

--- a/backend/app/api/session.py
+++ b/backend/app/api/session.py
@@ -2,31 +2,33 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
-from sqlalchemy.orm import sessionmaker
-from sqlmodel import Session
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
 class SessionProvider:
-    """Wrap a ``sessionmaker`` to expose dependency-friendly interfaces."""
+    """Wrap an async ``sessionmaker`` to expose dependency-friendly interfaces."""
 
-    def __init__(self, session_factory: sessionmaker) -> None:
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
 
-    @contextmanager
-    def session_scope(self) -> Iterator[Session]:
-        """Context manager yielding a managed SQLModel session."""
+    @asynccontextmanager
+    async def session_scope(self) -> AsyncIterator[AsyncSession]:
+        """Context manager yielding a managed SQLModel async session."""
 
-        session: Session = self._session_factory()
+        session: AsyncSession = self._session_factory()
         try:
             yield session
+        except Exception:
+            await session.rollback()
+            raise
         finally:
-            session.close()
+            await session.close()
 
-    def dependency(self) -> Iterator[Session]:
+    async def dependency(self) -> AsyncIterator[AsyncSession]:
         """FastAPI dependency that yields a session and ensures cleanup."""
 
-        with self.session_scope() as session:
+        async with self.session_scope() as session:
             yield session

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="KNOW_", env_file=".env", env_file_encoding="utf-8")
 
     database_url: str = (
-        "postgresql+psycopg://postgres:postgres@postgres:5432/knowledge"
+        "postgresql+psycopg_async://postgres:postgres@postgres:5432/knowledge"
     )
     otlp_endpoint: Optional[str] = None
     jaeger_host: str = "jaeger"

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -3,35 +3,30 @@ from __future__ import annotations
 
 from typing import Tuple
 
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
-from sqlmodel import Session, SQLModel, create_engine
+from sqlmodel import SQLModel
 
 
-def create_engine_and_session(*, url: str, echo: bool = False) -> Tuple[Engine, sessionmaker]:
-    """Create an engine and a session factory for the given URL.
+def create_async_engine_and_session(
+    *, url: str, echo: bool = False
+) -> Tuple[AsyncEngine, async_sessionmaker[AsyncSession]]:
+    """Create an async engine and session factory for the given URL."""
 
-    SQLite is configured with an in-memory friendly setup for tests while
-    PostgreSQL benefits from connection pre-ping for long running sessions.
-    """
-
-    connect_args = {}
-    engine_kwargs = {"echo": echo, "future": True}
-    if url.startswith("sqlite"):  # pragma: no cover - deterministic branch
-        connect_args = {"check_same_thread": False}
+    engine_kwargs: dict[str, object] = {"echo": echo, "future": True}
+    if url.startswith("sqlite+aiosqlite"):  # pragma: no cover - deterministic branch
+        engine_kwargs["connect_args"] = {"check_same_thread": False}
         engine_kwargs["poolclass"] = StaticPool
     else:
         engine_kwargs["pool_pre_ping"] = True
 
-    engine = create_engine(url, connect_args=connect_args, **engine_kwargs)
-    SQLModel.metadata.bind = engine
-    SessionLocal = sessionmaker(bind=engine, class_=Session, expire_on_commit=False)
-    return engine, SessionLocal
+    engine = create_async_engine(url, **engine_kwargs)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return engine, session_factory
 
 
-# Provide a helper for production usage.
-def init_db(url: str) -> Session:
-    engine, SessionLocal = create_engine_and_session(url=url)
-    SQLModel.metadata.create_all(engine)
-    return SessionLocal()
+async def init_db(url: str) -> AsyncSession:
+    engine, session_factory = create_async_engine_and_session(url=url)
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    return session_factory()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,10 +12,10 @@ from .api.routes import create_router
 from .api.session import SessionProvider
 from .ai.vllm import VLLMChatClient, VLLMEmbeddingClient
 from .config import Settings, get_settings
-from .database import create_engine_and_session
+from .database import create_async_engine_and_session
 from .observability import configure_logging, configure_tracing
 from .services import ContextNavigator, ContextNavigatorConfig, KnowledgeOrchestrator
-from .services.vector_index import NullVectorIndex
+from .services.vector_index import DistanceStrategy, PGVectorIndex
 
 
 def create_app(*, orchestrator: Optional[KnowledgeOrchestrator] = None) -> FastAPI:
@@ -28,15 +28,24 @@ def create_app(*, orchestrator: Optional[KnowledgeOrchestrator] = None) -> FastA
         otlp_endpoint=settings.otlp_endpoint,
     )
 
-    engine, session_factory = create_engine_and_session(url=settings.database_url)
+    engine, session_factory = create_async_engine_and_session(url=settings.database_url)
     session_provider = SessionProvider(session_factory)
-    orchestrator_instance = orchestrator or _build_default_orchestrator(settings)
+    embedding_client = VLLMEmbeddingClient(
+        base_url=settings.vllm_embedding_base_url,
+        model=settings.vllm_embedding_model,
+    )
+    orchestrator_instance = orchestrator or _build_default_orchestrator(
+        settings=settings,
+        session_factory=session_factory,
+        embedding_client=embedding_client,
+    )
 
     app = FastAPI(title="Live Knowledge Backend", version="0.1.0")
     app.state.engine = engine
     app.state.session_factory = session_factory
     app.state.session_provider = session_provider
     app.state.orchestrator = orchestrator_instance
+    app.state.embedding_client = embedding_client
     FastAPIInstrumentor.instrument_app(app, tracer_provider=trace.get_tracer_provider())
 
     app.include_router(create_router(session_provider, orchestrator_instance))
@@ -46,31 +55,34 @@ def create_app(*, orchestrator: Optional[KnowledgeOrchestrator] = None) -> FastA
         return {"status": "ok"}
 
     @app.on_event("startup")
-    def _create_tables() -> None:
-        SQLModel.metadata.create_all(engine)
+    async def _create_tables() -> None:
+        async with engine.begin() as connection:
+            await connection.run_sync(SQLModel.metadata.create_all)
 
     return app
 
 
-def _build_default_orchestrator(settings: Settings) -> KnowledgeOrchestrator:
-    embedding_client = VLLMEmbeddingClient(
-        base_url=settings.vllm_embedding_base_url,
-        model=settings.vllm_embedding_model,
-    )
+def _build_default_orchestrator(
+    *,
+    settings: Settings,
+    session_factory,
+    embedding_client: VLLMEmbeddingClient,
+) -> KnowledgeOrchestrator:
     chat_client = VLLMChatClient(
         base_url=settings.vllm_chat_base_url,
         model=settings.vllm_chat_model,
     )
+    vector_index = PGVectorIndex(session_factory=session_factory, embedding_client=embedding_client)
     navigator = ContextNavigator(
-        embedding_client=embedding_client,
-        vector_index=NullVectorIndex(),
+        vector_index=vector_index,
         config=ContextNavigatorConfig(
-            artifact_namespace="artifacts",
-            message_namespace="messages",
-            structured_namespace="structured_entries",
+            artifact_entity_type="artifact",
+            message_entity_type="message",
+            structured_entity_type="structured_entry",
             top_k_artifacts=settings.context_top_k_artifacts,
             top_k_messages=settings.context_top_k_messages,
             top_k_structured=settings.context_top_k_structured,
+            distance_strategy=DistanceStrategy.COSINE,
         ),
     )
     return KnowledgeOrchestrator(chat_client=chat_client, navigator=navigator)

--- a/backend/app/repositories.py
+++ b/backend/app/repositories.py
@@ -1,49 +1,71 @@
 """Repository layer implementing CRUD operations for domain entities."""
+
 from __future__ import annotations
 
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
 from uuid import UUID
 
 from sqlalchemy.orm import selectinload
-from sqlmodel import Session, select
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
 
 from .models import Artifact, Link, Message, Schema, StructuredEntry
+from .services.vector_index import EmbeddingClient
+
+
+@dataclass
+class _EmbeddingHelper:
+    client: EmbeddingClient | None
+
+    async def embed(self, text: Optional[str]) -> Optional[List[float]]:
+        if text is None:
+            return None
+        if not text.strip():
+            return None
+        if self.client is None:
+            raise RuntimeError("Embedding client is required for vector operations")
+        vectors = await self.client.embed([text])
+        if not vectors:
+            raise RuntimeError("Embedding service returned no vectors")
+        return [float(value) for value in vectors[0]]
 
 
 class ArtifactRepository:
     """Manage artifact persistence and hierarchy operations."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: AsyncSession, embedding_client: EmbeddingClient | None = None) -> None:
         self.session = session
+        self._embedding = _EmbeddingHelper(embedding_client)
 
-    def create(
+    async def create(
         self,
         *,
         title: str,
         summary: str,
-        summary_vector: Optional[List[float]],
+        summary_vector: Optional[Sequence[float]] = None,
         parent_artifact_id: Optional[UUID] = None,
         source_entry_id: Optional[UUID] = None,
         applied_schema_id: Optional[UUID] = None,
     ) -> Artifact:
+        vector = list(summary_vector) if summary_vector is not None else await self._embedding.embed(summary)
         artifact = Artifact(
             title=title,
             summary=summary,
-            summary_vector=summary_vector,
+            summary_vector=vector,
             parent_artifact_id=parent_artifact_id,
             source_entry_id=source_entry_id,
             applied_schema_id=applied_schema_id,
         )
         self.session.add(artifact)
-        self.session.commit()
-        self.session.refresh(artifact)
+        await self.session.commit()
+        await self.session.refresh(artifact)
         return artifact
 
-    def get(self, artifact_id: UUID) -> Optional[Artifact]:
-        statement = select(Artifact).where(Artifact.id == artifact_id)
-        return self.session.exec(statement).first()
+    async def get(self, artifact_id: UUID) -> Optional[Artifact]:
+        return await self.session.get(Artifact, artifact_id)
 
-    def get_with_related(self, artifact_id: UUID) -> Optional[Artifact]:
+    async def get_with_related(self, artifact_id: UUID) -> Optional[Artifact]:
         statement = (
             select(Artifact)
             .where(Artifact.id == artifact_id)
@@ -53,19 +75,20 @@ class ArtifactRepository:
                 selectinload(Artifact.structured_entries),
             )
         )
-        return self.session.exec(statement).first()
+        result = await self.session.execute(statement)
+        return result.scalars().first()
 
-    def create_child(
+    async def create_child(
         self,
         *,
         parent: Artifact,
         title: str,
         summary: str,
-        summary_vector: Optional[List[float]],
+        summary_vector: Optional[Sequence[float]] = None,
         source_entry_id: Optional[UUID] = None,
         applied_schema_id: Optional[UUID] = None,
     ) -> Artifact:
-        return self.create(
+        return await self.create(
             title=title,
             summary=summary,
             summary_vector=summary_vector,
@@ -74,108 +97,141 @@ class ArtifactRepository:
             applied_schema_id=applied_schema_id,
         )
 
+    async def update_summary(self, *, artifact: Artifact, summary: str) -> Artifact:
+        artifact.summary = summary
+        artifact.summary_vector = await self._embedding.embed(summary)
+        self.session.add(artifact)
+        await self.session.commit()
+        await self.session.refresh(artifact)
+        return artifact
+
 
 class SchemaRepository:
     """CRUD operations for schemas."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: AsyncSession) -> None:
         self.session = session
 
-    def create(
+    async def create(
         self,
         *,
         name: str,
         description: str,
         schema_json: dict,
-        description_vector: Optional[List[float]],
+        description_vector: Optional[Sequence[float]] = None,
     ) -> Schema:
         schema = Schema(
             name=name,
             description=description,
             schema_json=schema_json,
-            description_vector=description_vector,
+            description_vector=list(description_vector) if description_vector is not None else None,
         )
         self.session.add(schema)
-        self.session.commit()
-        self.session.refresh(schema)
+        await self.session.commit()
+        await self.session.refresh(schema)
         return schema
 
-    def get(self, schema_id: UUID) -> Optional[Schema]:
-        return self.session.get(Schema, schema_id)
+    async def get(self, schema_id: UUID) -> Optional[Schema]:
+        return await self.session.get(Schema, schema_id)
 
 
 class StructuredEntryRepository:
     """Access structured knowledge entries."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: AsyncSession, embedding_client: EmbeddingClient | None = None) -> None:
         self.session = session
+        self._embedding = _EmbeddingHelper(embedding_client)
 
-    def create(
+    async def create(
         self,
         *,
         artifact: Artifact,
         data_json: dict,
         text_representation: str,
-        vector: Optional[List[float]],
+        vector: Optional[Sequence[float]] = None,
         schema: Optional[Schema] = None,
     ) -> StructuredEntry:
+        entry_vector = list(vector) if vector is not None else await self._embedding.embed(text_representation)
         entry = StructuredEntry(
             artifact_id=artifact.id,
             data_json=data_json,
             text_representation=text_representation,
-            text_representation_vector=vector,
+            text_representation_vector=entry_vector,
             schema_id=schema.id if schema else None,
         )
         self.session.add(entry)
-        self.session.commit()
-        self.session.refresh(entry)
+        await self.session.commit()
+        await self.session.refresh(entry)
         return entry
 
-    def get(self, entry_id: UUID) -> Optional[StructuredEntry]:
-        return self.session.get(StructuredEntry, entry_id)
+    async def get(self, entry_id: UUID) -> Optional[StructuredEntry]:
+        return await self.session.get(StructuredEntry, entry_id)
+
+    async def update_text_representation(
+        self,
+        *,
+        entry: StructuredEntry,
+        text_representation: str,
+        data_json: dict | None = None,
+    ) -> StructuredEntry:
+        entry.text_representation = text_representation
+        if data_json is not None:
+            entry.data_json = data_json
+        entry.text_representation_vector = await self._embedding.embed(text_representation)
+        self.session.add(entry)
+        await self.session.commit()
+        await self.session.refresh(entry)
+        return entry
 
 
 class MessageRepository:
     """Persistence helpers for chat messages."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: AsyncSession, embedding_client: EmbeddingClient | None = None) -> None:
         self.session = session
+        self._embedding = _EmbeddingHelper(embedding_client)
 
-    def create(
+    async def create(
         self,
         *,
         artifact: Artifact,
         content: str,
         sender: Optional[str],
-        vector: Optional[List[float]] = None,
+        vector: Optional[Sequence[float]] = None,
     ) -> Message:
+        message_vector = list(vector) if vector is not None else await self._embedding.embed(content)
         message = Message(
             artifact_id=artifact.id,
             content=content,
             sender=sender,
-            content_vector=vector,
+            content_vector=message_vector,
         )
         self.session.add(message)
-        self.session.commit()
-        self.session.refresh(message)
+        await self.session.commit()
+        await self.session.refresh(message)
         return message
 
-    def list_for_artifact(self, artifact_id: UUID) -> List[Message]:
-        statement = (
-            select(Message)
-            .where(Message.artifact_id == artifact_id)
-            .order_by(Message.created_at)
-        )
-        return list(self.session.exec(statement))
+    async def update_content(self, *, message: Message, content: str) -> Message:
+        message.content = content
+        message.content_vector = await self._embedding.embed(content)
+        self.session.add(message)
+        await self.session.commit()
+        await self.session.refresh(message)
+        return message
+
+    async def list_for_artifact(self, artifact_id: UUID) -> List[Message]:
+        statement = select(Message).where(Message.artifact_id == artifact_id).order_by(Message.created_at)
+        result = await self.session.execute(statement)
+        return list(result.scalars())
 
 
 class LinkRepository:
     """Knowledge graph link operations."""
 
-    def __init__(self, session: Session) -> None:
+    def __init__(self, session: AsyncSession) -> None:
         self.session = session
 
-    def create(
+    async def create(
         self,
         *,
         source_type: str,
@@ -194,16 +250,17 @@ class LinkRepository:
             description=description,
         )
         self.session.add(link)
-        self.session.commit()
-        self.session.refresh(link)
+        await self.session.commit()
+        await self.session.refresh(link)
         return link
 
-    def list_for_entity(self, *, entity_type: str, entity_id: UUID) -> List[Link]:
+    async def list_for_entity(self, *, entity_type: str, entity_id: UUID) -> List[Link]:
         statement = select(Link).where(
             (Link.source_entity_type == entity_type) & (Link.source_entity_id == str(entity_id))
         )
-        return list(self.session.exec(statement))
+        result = await self.session.execute(statement)
+        return list(result.scalars())
 
-    def delete(self, link: Link) -> None:
-        self.session.delete(link)
-        self.session.commit()
+    async def delete(self, link: Link) -> None:
+        await self.session.delete(link)
+        await self.session.commit()

--- a/backend/app/services/context_navigator.py
+++ b/backend/app/services/context_navigator.py
@@ -2,26 +2,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable, Mapping, Protocol, Sequence
+from typing import Iterable, Mapping, Sequence
 
-
-class EmbeddingClient(Protocol):
-    async def embed(self, texts: Sequence[str]) -> Sequence[Sequence[float]]: ...
-
-
-class VectorIndex(Protocol):
-    async def search(
-        self, namespace: str, vector: Sequence[float], limit: int
-    ) -> Sequence["SearchHit"] | Sequence[Mapping[str, object]]: ...
-
-
-@dataclass(slots=True)
-class SearchHit:
-    """Structured representation of a vector search result."""
-
-    id: str
-    score: float
-    payload: Mapping[str, object]
+from .search_types import SearchHit, VectorIndex
+from .vector_index import DistanceStrategy
 
 
 @dataclass(slots=True)
@@ -36,12 +20,13 @@ class ContextResult:
 
 @dataclass(slots=True)
 class ContextNavigatorConfig:
-    artifact_namespace: str
-    message_namespace: str
-    structured_namespace: str
+    artifact_entity_type: str
+    message_entity_type: str
+    structured_entity_type: str
     top_k_artifacts: int = 5
     top_k_messages: int = 5
     top_k_structured: int = 5
+    distance_strategy: DistanceStrategy = DistanceStrategy.COSINE
 
 
 class ContextNavigator:
@@ -50,33 +35,26 @@ class ContextNavigator:
     def __init__(
         self,
         *,
-        embedding_client: EmbeddingClient,
         vector_index: VectorIndex,
         config: ContextNavigatorConfig,
     ) -> None:
-        self._embedding = embedding_client
         self._index = vector_index
         self._config = config
 
     async def collect(self, query: str) -> ContextResult:
-        vectors = await self._embedding.embed([query])
-        if not vectors:
-            raise RuntimeError("Embedding client returned no vectors for query")
-        vector = list(vectors[0])
-
         artifacts = await self._search(
-            namespace=self._config.artifact_namespace,
-            vector=vector,
+            query=query,
+            entity_type=self._config.artifact_entity_type,
             limit=self._config.top_k_artifacts,
         )
         messages = await self._search(
-            namespace=self._config.message_namespace,
-            vector=vector,
+            query=query,
+            entity_type=self._config.message_entity_type,
             limit=self._config.top_k_messages,
         )
         structured = await self._search(
-            namespace=self._config.structured_namespace,
-            vector=vector,
+            query=query,
+            entity_type=self._config.structured_entity_type,
             limit=self._config.top_k_structured,
         )
 
@@ -87,15 +65,20 @@ class ContextNavigator:
             structured_entries=structured,
         )
 
-    async def _search(self, *, namespace: str, vector: Sequence[float], limit: int) -> list[SearchHit]:
+    async def _search(self, *, query: str, entity_type: str, limit: int) -> list[SearchHit]:
         if limit <= 0:
             return []
-        raw_results = await self._index.search(namespace, vector, limit)
-        hits = [_coerce_hit(result) for result in raw_results]
+        raw_results = await self._index.search(
+            query,
+            entity_types=[entity_type],
+            limit=limit,
+            distance_strategy=self._config.distance_strategy,
+        )
+        hits = [_coerce_hit(result, default_entity_type=entity_type) for result in raw_results]
         return hits[:limit]
 
 
-def _coerce_hit(result: SearchHit | Mapping[str, object]) -> SearchHit:
+def _coerce_hit(result: SearchHit | Mapping[str, object], *, default_entity_type: str) -> SearchHit:
     if isinstance(result, SearchHit):
         return result
 
@@ -103,14 +86,18 @@ def _coerce_hit(result: SearchHit | Mapping[str, object]) -> SearchHit:
         identifier = result.get("id")
         score = result.get("score")
         payload = result.get("payload")
+        entity_type = result.get("entity_type")
     else:
         identifier = getattr(result, "id", None)
         score = getattr(result, "score", None)
         payload = getattr(result, "payload", {})
+        entity_type = getattr(result, "entity_type", None)
 
     if not isinstance(identifier, str) or not isinstance(score, (int, float)):
         raise TypeError("Vector index result missing id or score")
     if not isinstance(payload, Mapping):
         payload = {}
+    if not isinstance(entity_type, str):
+        entity_type = default_entity_type
 
-    return SearchHit(id=identifier, score=float(score), payload=payload)
+    return SearchHit(id=identifier, score=float(score), payload=payload, entity_type=entity_type)

--- a/backend/app/services/search_types.py
+++ b/backend/app/services/search_types.py
@@ -1,0 +1,26 @@
+"""Shared types for vector search operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence
+
+
+@dataclass(slots=True)
+class SearchHit:
+    id: str
+    score: float
+    payload: Mapping[str, object]
+    entity_type: str
+
+
+class VectorIndex(Protocol):
+    async def search(
+        self,
+        query: str,
+        *,
+        entity_types: Sequence[str],
+        limit: int,
+        distance_strategy: object,
+    ) -> Sequence[SearchHit] | Sequence[Mapping[str, object]]:
+        ...

--- a/backend/app/services/vector_index.py
+++ b/backend/app/services/vector_index.py
@@ -1,22 +1,235 @@
 """Vector index implementations used by the AI services."""
 from __future__ import annotations
 
-from typing import Sequence
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Iterable, Mapping, Sequence, Protocol
 
-from .context_navigator import SearchHit, VectorIndex
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.sql import Select
+from sqlmodel import SQLModel
+
+from ..models import Artifact, Message, StructuredEntry
+from .search_types import SearchHit, VectorIndex
+
+
+class DistanceStrategy(str, Enum):
+    COSINE = "cosine_distance"
+    L2 = "l2_distance"
+
+
+class EmbeddingClient(Protocol):
+    async def embed(self, texts: Sequence[str]) -> Sequence[Sequence[float]]: ...
+
+
+@dataclass(frozen=True)
+class EntityConfig:
+    model: type[SQLModel]
+    id_attribute: str
+    vector_attribute: str
+    payload_factory: Callable[[SQLModel], Mapping[str, object]]
+
+
+_DEFAULT_ENTITY_CONFIG: Mapping[str, EntityConfig] = {
+    "artifact": EntityConfig(
+        model=Artifact,
+        id_attribute="id",
+        vector_attribute="summary_vector",
+        payload_factory=lambda instance: {
+            "title": getattr(instance, "title", ""),
+            "summary": getattr(instance, "summary", ""),
+            "parent_artifact_id": getattr(instance, "parent_artifact_id", None),
+        },
+    ),
+    "message": EntityConfig(
+        model=Message,
+        id_attribute="id",
+        vector_attribute="content_vector",
+        payload_factory=lambda instance: {
+            "artifact_id": getattr(instance, "artifact_id", None),
+            "sender": getattr(instance, "sender", None),
+            "content": getattr(instance, "content", ""),
+        },
+    ),
+    "structured_entry": EntityConfig(
+        model=StructuredEntry,
+        id_attribute="id",
+        vector_attribute="text_representation_vector",
+        payload_factory=lambda instance: {
+            "artifact_id": getattr(instance, "artifact_id", None),
+            "schema_id": getattr(instance, "schema_id", None),
+            "text_representation": getattr(instance, "text_representation", ""),
+        },
+    ),
+}
+
+
+class PGVectorIndex(VectorIndex):
+    """Run semantic search queries against the application's database."""
+
+    def __init__(
+        self,
+        *,
+        session_factory: async_sessionmaker[AsyncSession],
+        embedding_client: EmbeddingClient,
+        entity_config: Mapping[str, EntityConfig] | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._embedding = embedding_client
+        self._entity_config = dict(entity_config or _DEFAULT_ENTITY_CONFIG)
+
+    async def search(
+        self,
+        query: str,
+        *,
+        entity_types: Sequence[str],
+        limit: int,
+        distance_strategy: DistanceStrategy = DistanceStrategy.COSINE,
+    ) -> list[SearchHit]:
+        if not query or limit <= 0:
+            return []
+
+        vectors = await self._embedding.embed([query])
+        if not vectors:
+            raise RuntimeError("Embedding client returned no vectors for query")
+        query_vector = list(vectors[0])
+
+        hits: list[SearchHit] = []
+        async with self._session_factory() as session:
+            for entity_type in entity_types:
+                config = self._entity_config.get(entity_type)
+                if not config:
+                    continue
+                rows = await self._load_candidates(
+                    session=session,
+                    config=config,
+                    limit=limit,
+                    query_vector=query_vector,
+                    strategy=distance_strategy,
+                )
+                hits.extend(
+                    self._score_candidates(
+                        candidates=rows,
+                        config=config,
+                        entity_type=entity_type,
+                        query_vector=query_vector,
+                        strategy=distance_strategy,
+                    )
+                )
+
+        hits.sort(key=lambda item: item.score, reverse=True)
+        return hits[:limit]
+
+    async def _load_candidates(
+        self,
+        *,
+        session: AsyncSession,
+        config: EntityConfig,
+        limit: int,
+        query_vector: Sequence[float],
+        strategy: DistanceStrategy,
+    ) -> Sequence[SQLModel]:
+        column = getattr(config.model, config.vector_attribute)
+        statement: Select[tuple[SQLModel]] = select(config.model).where(column.is_not(None))
+        if self._supports_database_vectors(session):
+            distance_expression = self._build_distance_expression(
+                column=column,
+                query_vector=query_vector,
+                strategy=strategy,
+            )
+            statement = statement.order_by(distance_expression).limit(limit)
+        result = await session.execute(statement)
+        return result.scalars().all()
+
+    @staticmethod
+    def _supports_database_vectors(session: AsyncSession) -> bool:
+        bind = session.bind
+        if bind is None:  # pragma: no cover - defensive guard
+            return False
+        return getattr(bind.dialect, "name", "") == "postgresql"
+
+    @staticmethod
+    def _build_distance_expression(
+        *, column, query_vector: Sequence[float], strategy: DistanceStrategy
+    ):
+        try:
+            distance_callable = getattr(column, strategy.value)
+        except AttributeError as exc:  # pragma: no cover - database misconfiguration
+            raise RuntimeError(
+                f"Vector column does not support distance strategy {strategy}"
+            ) from exc
+        return distance_callable(list(query_vector))
+
+    def _score_candidates(
+        self,
+        *,
+        candidates: Iterable[SQLModel],
+        config: EntityConfig,
+        entity_type: str,
+        query_vector: Sequence[float],
+        strategy: DistanceStrategy,
+    ) -> list[SearchHit]:
+        hits: list[SearchHit] = []
+        for candidate in candidates:
+            candidate_vector = getattr(candidate, config.vector_attribute, None)
+            if not candidate_vector:
+                continue
+            score = _compute_similarity(query_vector, candidate_vector, strategy)
+            payload = dict(config.payload_factory(candidate))
+            hits.append(
+                SearchHit(
+                    id=str(getattr(candidate, config.id_attribute)),
+                    score=score,
+                    payload=payload,
+                    entity_type=entity_type,
+                )
+            )
+        return hits
+
+
+def _compute_similarity(
+    query_vector: Sequence[float],
+    candidate_vector: Sequence[float],
+    strategy: DistanceStrategy,
+) -> float:
+    if strategy is DistanceStrategy.COSINE:
+        return _cosine_similarity(query_vector, candidate_vector)
+    if strategy is DistanceStrategy.L2:
+        return _l2_similarity(query_vector, candidate_vector)
+    raise ValueError(f"Unsupported distance strategy: {strategy}")
+
+
+def _cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    similarity = dot / (norm_a * norm_b)
+    similarity = max(-1.0, min(1.0, similarity))
+    # Normalize from [-1, 1] to [0, 1]
+    return 0.5 * (similarity + 1.0)
+
+
+def _l2_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    distance = math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+    return 1.0 / (1.0 + distance)
 
 
 class NullVectorIndex(VectorIndex):
-    """Fallback vector index that returns no results.
-
-    This keeps the orchestration pipeline operational even when a real
-    similarity search backend is not yet configured.
-    """
+    """Fallback vector index that returns no results."""
 
     async def search(
-        self, namespace: str, vector: Sequence[float], limit: int
-    ) -> Sequence[SearchHit]:
+        self,
+        query: str,
+        *,
+        entity_types: Sequence[str],
+        limit: int,
+        distance_strategy: DistanceStrategy,
+    ) -> list[SearchHit]:
         return []
 
 
-__all__ = ["NullVectorIndex"]
+__all__ = ["DistanceStrategy", "EntityConfig", "NullVectorIndex", "PGVectorIndex"]

--- a/backend/tests/services/test_context_navigator.py
+++ b/backend/tests/services/test_context_navigator.py
@@ -1,57 +1,70 @@
 from dataclasses import dataclass
 from typing import List
 
+from typing import Sequence
+
 import pytest
 
-from app.services.context_navigator import ContextNavigator, ContextNavigatorConfig, ContextResult
-
-
-class FakeEmbeddingClient:
-    def __init__(self) -> None:
-        self.calls: List[List[str]] = []
-
-    async def embed(self, texts: List[str]) -> List[List[float]]:
-        self.calls.append(texts)
-        return [[0.1, 0.2, 0.3]]
-
-
-@dataclass
-class FakeSearchResult:
-    id: str
-    score: float
-    payload: dict
+from app.services.context_navigator import (
+    ContextNavigator,
+    ContextNavigatorConfig,
+    ContextResult,
+    SearchHit,
+)
+from app.services.vector_index import DistanceStrategy
 
 
 class FakeVectorIndex:
     def __init__(self) -> None:
-        self.requests: list[tuple[str, List[float], int]] = []
+        self.requests: list[tuple[str, tuple[str, ...], int, DistanceStrategy]] = []
 
-    async def search(self, namespace: str, vector: List[float], limit: int) -> List[FakeSearchResult]:
-        self.requests.append((namespace, vector, limit))
-        if namespace == "artifacts":
+    async def search(
+        self,
+        query: str,
+        *,
+        entity_types: Sequence[str],
+        limit: int,
+        distance_strategy: DistanceStrategy,
+    ) -> list[SearchHit]:
+        self.requests.append((query, tuple(entity_types), limit, distance_strategy))
+        entity_type = entity_types[0]
+        if entity_type == "artifact":
             return [
-                FakeSearchResult(id="1", score=0.9, payload={"title": "Artifact"}),
+                SearchHit(
+                    id="1",
+                    score=0.9,
+                    payload={"title": "Artifact"},
+                    entity_type="artifact",
+                )
             ]
-        if namespace == "messages":
+        if entity_type == "message":
             return [
-                FakeSearchResult(id="2", score=0.8, payload={"content": "Message"}),
+                SearchHit(
+                    id="2",
+                    score=0.8,
+                    payload={"content": "Message"},
+                    entity_type="message",
+                )
             ]
         return [
-            FakeSearchResult(id="3", score=0.7, payload={"text": "Structured"}),
+            SearchHit(
+                id="3",
+                score=0.7,
+                payload={"text": "Structured"},
+                entity_type="structured_entry",
+            )
         ]
 
 
 @pytest.mark.asyncio
-async def test_navigator_embeds_and_queries_index() -> None:
-    embedding = FakeEmbeddingClient()
+async def test_navigator_queries_index_per_entity_type() -> None:
     index = FakeVectorIndex()
     navigator = ContextNavigator(
-        embedding_client=embedding,
         vector_index=index,
         config=ContextNavigatorConfig(
-            artifact_namespace="artifacts",
-            message_namespace="messages",
-            structured_namespace="structured_entries",
+            artifact_entity_type="artifact",
+            message_entity_type="message",
+            structured_entity_type="structured_entry",
             top_k_artifacts=1,
             top_k_messages=1,
             top_k_structured=1,
@@ -60,11 +73,10 @@ async def test_navigator_embeds_and_queries_index() -> None:
 
     result = await navigator.collect("Hello world")
 
-    assert embedding.calls == [["Hello world"]]
     assert index.requests == [
-        ("artifacts", [0.1, 0.2, 0.3], 1),
-        ("messages", [0.1, 0.2, 0.3], 1),
-        ("structured_entries", [0.1, 0.2, 0.3], 1),
+        ("Hello world", ("artifact",), 1, DistanceStrategy.COSINE),
+        ("Hello world", ("message",), 1, DistanceStrategy.COSINE),
+        ("Hello world", ("structured_entry",), 1, DistanceStrategy.COSINE),
     ]
     assert isinstance(result, ContextResult)
     assert result.artifacts[0].payload["title"] == "Artifact"

--- a/backend/tests/services/test_orchestrator.py
+++ b/backend/tests/services/test_orchestrator.py
@@ -8,9 +8,30 @@ class FakeNavigator:
     async def collect(self, message: str) -> ContextResult:
         return ContextResult(
             query=message,
-            artifacts=[SearchHit(id="a1", score=0.9, payload={"title": "Artifact A", "summary": "Summary"})],
-            messages=[SearchHit(id="m1", score=0.8, payload={"content": "Message content"})],
-            structured_entries=[SearchHit(id="s1", score=0.7, payload={"text": "Structured"})],
+            artifacts=[
+                SearchHit(
+                    id="a1",
+                    score=0.9,
+                    payload={"title": "Artifact A", "summary": "Summary"},
+                    entity_type="artifact",
+                )
+            ],
+            messages=[
+                SearchHit(
+                    id="m1",
+                    score=0.8,
+                    payload={"content": "Message content"},
+                    entity_type="message",
+                )
+            ],
+            structured_entries=[
+                SearchHit(
+                    id="s1",
+                    score=0.7,
+                    payload={"text": "Structured"},
+                    entity_type="structured_entry",
+                )
+            ],
         )
 
 

--- a/backend/tests/services/test_vector_index.py
+++ b/backend/tests/services/test_vector_index.py
@@ -1,0 +1,163 @@
+import math
+from typing import Sequence
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import literal
+from sqlalchemy.sql import Select
+from sqlmodel import SQLModel
+
+from app.database import create_async_engine_and_session
+from app.models import Artifact, Message, StructuredEntry
+from app.services.vector_index import DistanceStrategy, PGVectorIndex
+
+
+class _FakeResult:
+    def __init__(self, items: Sequence[SQLModel]) -> None:
+        self._items = list(items)
+
+    def scalars(self) -> "_FakeResult":
+        return self
+
+    def all(self) -> list[SQLModel]:
+        return list(self._items)
+
+
+class _FakeSessionContext:
+    def __init__(self, session: "_FakeSession") -> None:
+        self._session = session
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - no cleanup required
+        return None
+
+
+class _FakeSession:
+    def __init__(self, items: Sequence[SQLModel]) -> None:
+        from types import SimpleNamespace
+
+        self._items = list(items)
+        self.statements: list[Select] = []
+        self.bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+    async def execute(self, statement: Select) -> _FakeResult:
+        self.statements.append(statement)
+        return _FakeResult(self._items)
+
+
+def _postgres_session_factory(items: Sequence[SQLModel]):
+    session = _FakeSession(items)
+
+    def factory() -> _FakeSessionContext:
+        return _FakeSessionContext(session)
+
+    factory.session = session  # type: ignore[attr-defined]
+    return factory
+
+
+class FakeEmbeddingClient:
+    def __init__(self, vector: Sequence[float]) -> None:
+        self._vector = list(vector)
+        self.calls: list[tuple[str, ...]] = []
+
+    async def embed(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        self.calls.append(tuple(texts))
+        return [self._vector]
+
+
+@pytest_asyncio.fixture()
+async def session_factory():
+    engine, factory = create_async_engine_and_session(url="sqlite+aiosqlite:///:memory:?cache=shared")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_pgvector_index_filters_by_entity_type(session_factory) -> None:
+    embedding = FakeEmbeddingClient([1.0, 0.0, 0.0])
+    index = PGVectorIndex(session_factory=session_factory, embedding_client=embedding)
+
+    async with session_factory() as session:
+        artifact = Artifact(title="Root", summary="hello", summary_vector=[1.0, 0.0, 0.0])
+        other_artifact = Artifact(title="Other", summary="bye", summary_vector=[0.0, 1.0, 0.0])
+        message = Message(
+            artifact_id=artifact.id,
+            content="Message",
+            sender="user",
+            content_vector=[1.0, 0.0, 0.0],
+        )
+        session.add(artifact)
+        session.add(other_artifact)
+        session.add(message)
+        await session.commit()
+        artifact_id = str(artifact.id)
+        other_artifact_id = str(other_artifact.id)
+
+    hits = await index.search("Root", entity_types=["artifact"], limit=2)
+
+    assert embedding.calls == [("Root",)]
+    assert [hit.entity_type for hit in hits] == ["artifact", "artifact"]
+    assert hits[0].id == artifact_id
+    assert hits[1].id == other_artifact_id
+
+
+@pytest.mark.asyncio
+async def test_pgvector_index_supports_l2_distance(session_factory) -> None:
+    embedding = FakeEmbeddingClient([0.0, 0.0, 1.0])
+    index = PGVectorIndex(session_factory=session_factory, embedding_client=embedding)
+
+    async with session_factory() as session:
+        entry = StructuredEntry(
+            artifact_id=uuid4(),
+            data_json={"value": 1},
+            text_representation="value: 1",
+            text_representation_vector=[0.0, 0.0, 0.0],
+        )
+        session.add(entry)
+        await session.commit()
+
+    hits = await index.search(
+        "value",
+        entity_types=["structured_entry"],
+        limit=1,
+        distance_strategy=DistanceStrategy.L2,
+    )
+
+    assert hits[0].entity_type == "structured_entry"
+    assert math.isclose(hits[0].score, 0.5, rel_tol=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_pgvector_index_uses_database_distance_on_postgres(monkeypatch) -> None:
+    artifact = Artifact(title="Root", summary="hello", summary_vector=[1.0, 0.0, 0.0])
+    other = Artifact(title="Other", summary="bye", summary_vector=[0.0, 1.0, 0.0])
+    session_factory = _postgres_session_factory([artifact, other])
+    embedding = FakeEmbeddingClient([1.0, 0.0, 0.0])
+    index = PGVectorIndex(session_factory=session_factory, embedding_client=embedding)
+
+    calls: list[tuple[object, list[float], DistanceStrategy]] = []
+
+    def fake_distance(*, column, query_vector, strategy):
+        calls.append((column, list(query_vector), strategy))
+        return literal(0)
+
+    monkeypatch.setattr(
+        PGVectorIndex,
+        "_build_distance_expression",
+        staticmethod(fake_distance),
+    )
+
+    hits = await index.search("Root", entity_types=["artifact"], limit=1)
+
+    assert len(hits) == 1
+    statement = session_factory.session.statements[0]
+    assert statement._order_by_clause is not None and statement._order_by_clause.clauses
+    assert statement._limit_clause is not None
+    assert calls and calls[0][2] is DistanceStrategy.COSINE

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,21 +1,24 @@
-"""End-to-end tests for the FastAPI application (stream D)."""
-
-from __future__ import annotations
-
-from uuid import UUID
-
 import pytest
+import pytest_asyncio
 from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
+from app.api.dependencies import get_embedding_client
 from app.config import get_settings
 from app.main import create_app
+from app.repositories import ArtifactRepository, MessageRepository, StructuredEntryRepository
 from app.services.context_navigator import ContextResult, SearchHit
 from app.services.orchestrator import GenerationRequest, GenerationResponse
-from app.repositories import (
-    ArtifactRepository,
-    MessageRepository,
-    StructuredEntryRepository,
-)
+
+
+class FakeEmbeddingClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.vector = [0.5, 0.5, 0.5]
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(tuple(texts))
+        return [self.vector for _ in texts]
 
 
 class FakeOrchestrator:
@@ -28,12 +31,15 @@ class FakeOrchestrator:
             content="Ответ ассистента",
             context=ContextResult(
                 query=request.user_message,
-                artifacts=[
-                    SearchHit(id="a1", score=0.9, payload={"title": "Artifact"}),
-                ],
-                messages=[SearchHit(id="m1", score=0.8, payload={"content": "Message"})],
+                artifacts=[SearchHit(id="a1", score=0.9, payload={"title": "Artifact"}, entity_type="artifact")],
+                messages=[SearchHit(id="m1", score=0.8, payload={"content": "Message"}, entity_type="message")],
                 structured_entries=[
-                    SearchHit(id="s1", score=0.7, payload={"text": "Structured"}),
+                    SearchHit(
+                        id="s1",
+                        score=0.7,
+                        payload={"text": "Structured"},
+                        entity_type="structured_entry",
+                    )
                 ],
             ),
         )
@@ -44,38 +50,49 @@ def fake_orchestrator() -> FakeOrchestrator:
     return FakeOrchestrator()
 
 
-@pytest.fixture()
-def app(monkeypatch: pytest.MonkeyPatch, fake_orchestrator: FakeOrchestrator):
-    """Build an application instance backed by an in-memory database."""
-
+@pytest_asyncio.fixture()
+async def app(monkeypatch: pytest.MonkeyPatch, fake_orchestrator: FakeOrchestrator):
     get_settings.cache_clear()
-    monkeypatch.setenv("KNOW_DATABASE_URL", "sqlite://")
-    return create_app(orchestrator=fake_orchestrator)
+    monkeypatch.setenv("KNOW_DATABASE_URL", "sqlite+aiosqlite:///./test_api.db")
+    application = create_app(orchestrator=fake_orchestrator)
+    return application
 
 
-@pytest.fixture()
-def client(app):
-    with TestClient(app) as client:
-        yield client
+@pytest_asyncio.fixture()
+async def client(app, embedding_client: FakeEmbeddingClient):
+    app.dependency_overrides[get_embedding_client] = lambda: embedding_client
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+            yield async_client
+    app.dependency_overrides.clear()
 
 
-@pytest.fixture()
-def session_factory(app):
+@pytest_asyncio.fixture()
+async def embedding_client() -> FakeEmbeddingClient:
+    return FakeEmbeddingClient()
+
+
+@pytest_asyncio.fixture()
+async def session_factory(app):
     return app.state.session_factory
 
 
-@pytest.fixture()
-def artifact(session_factory) -> UUID:
-    with session_factory() as session:
-        repo = ArtifactRepository(session)
-        artifact = repo.create(title="Root", summary="", summary_vector=None)
+@pytest_asyncio.fixture()
+async def artifact(session_factory, embedding_client: FakeEmbeddingClient):
+    async with session_factory() as session:
+        repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+        artifact = await repo.create(title="Root", summary="Root summary")
         return artifact.id
 
 
-def test_post_chat_message_triggers_ai_and_persists_messages(client, session_factory, artifact, fake_orchestrator):
+@pytest.mark.asyncio
+async def test_post_chat_message_triggers_ai_and_persists_messages(
+    client: AsyncClient, session_factory, artifact, fake_orchestrator, embedding_client: FakeEmbeddingClient
+):
     payload = {"artifact_id": str(artifact), "content": "Привет", "sender": "user"}
 
-    response = client.post("/chat/message", json=payload)
+    response = await client.post("/chat/message", json=payload)
 
     assert response.status_code == 200
     body = response.json()
@@ -91,38 +108,36 @@ def test_post_chat_message_triggers_ai_and_persists_messages(client, session_fac
     assert request.user_message == "Привет"
     assert list(request.conversation_history) == []
 
-    with session_factory() as session:
-        messages = MessageRepository(session).list_for_artifact(artifact_id=artifact)
+    async with session_factory() as session:
+        messages = await MessageRepository(session=session).list_for_artifact(artifact_id=artifact)
         assert len(messages) == 2
         assert messages[0].content == "Привет"
         assert messages[0].sender == "user"
+        assert messages[0].content_vector == embedding_client.vector
         assert messages[1].content == "Ответ ассистента"
         assert messages[1].sender == "assistant"
+        assert messages[1].content_vector == embedding_client.vector
 
 
-def test_get_artifact_returns_nested_payload(client, session_factory, artifact):
-    with session_factory() as session:
-        artifact_repo = ArtifactRepository(session)
-        entry_repo = StructuredEntryRepository(session)
-        message_repo = MessageRepository(session)
+@pytest.mark.asyncio
+async def test_get_artifact_returns_nested_payload(client: AsyncClient, session_factory, artifact, embedding_client):
+    async with session_factory() as session:
+        artifact_repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+        entry_repo = StructuredEntryRepository(session=session, embedding_client=embedding_client)
+        message_repo = MessageRepository(session=session, embedding_client=embedding_client)
 
-        stored_artifact = artifact_repo.get(artifact)
+        stored_artifact = await artifact_repo.get(artifact)
         assert stored_artifact is not None
 
-        message_repo.create(
-            artifact=stored_artifact,
-            content="Запланировать релиз",
-            sender="alice",
-        )
+        await message_repo.create(artifact=stored_artifact, content="Запланировать релиз", sender="alice")
 
-        entry_repo.create(
+        await entry_repo.create(
             artifact=stored_artifact,
             data_json={"task": "Release"},
             text_representation="task: Release",
-            vector=None,
         )
 
-    response = client.get(f"/artifacts/{artifact}")
+    response = await client.get(f"/artifacts/{artifact}")
     assert response.status_code == 200
 
     body = response.json()
@@ -131,14 +146,15 @@ def test_get_artifact_returns_nested_payload(client, session_factory, artifact):
     assert body["structured_entries"][0]["data_json"] == {"task": "Release"}
 
 
-def test_post_artifact_link(client, session_factory, artifact):
-    with session_factory() as session:
-        target = ArtifactRepository(session).create(
-            title="Target", summary="", summary_vector=None
+@pytest.mark.asyncio
+async def test_post_artifact_link(client: AsyncClient, session_factory, artifact, embedding_client):
+    async with session_factory() as session:
+        target = await ArtifactRepository(session=session, embedding_client=embedding_client).create(
+            title="Target", summary="Target summary"
         )
         target_id = target.id
 
-    response = client.post(
+    response = await client.post(
         f"/artifacts/{artifact}/links",
         json={
             "target_entity_type": "artifact",
@@ -154,15 +170,23 @@ def test_post_artifact_link(client, session_factory, artifact):
     assert data["target_entity_id"] == str(target_id)
 
 
-def test_websocket_chat_persists_messages(client, session_factory, artifact):
-    with client.websocket_connect(f"/ws/chat/{artifact}") as websocket:
-        websocket.send_json({"content": "Через WS", "sender": "bob"})
-        response = websocket.receive_json()
+@pytest.mark.asyncio
+async def test_websocket_chat_persists_messages(app, session_factory, artifact, embedding_client):
+    app.dependency_overrides[get_embedding_client] = lambda: embedding_client
+    with TestClient(app) as sync_client:
+        with sync_client.websocket_connect(f"/ws/chat/{artifact}") as websocket:
+            websocket.send_json({"content": "Через WS", "sender": "bob"})
+            response = websocket.receive_json()
+
+    app.dependency_overrides.clear()
 
     assert response["content"] == "Через WS"
     assert response["artifact_id"] == str(artifact)
 
-    with session_factory() as session:
-        messages = MessageRepository(session).list_for_artifact(artifact_id=artifact)
+    async with session_factory() as session:
+        messages = await MessageRepository(session=session, embedding_client=embedding_client).list_for_artifact(
+            artifact_id=artifact
+        )
         assert len(messages) == 1
         assert messages[0].sender == "bob"
+        assert messages[0].content_vector == embedding_client.vector

--- a/backend/tests/test_repositories.py
+++ b/backend/tests/test_repositories.py
@@ -1,84 +1,105 @@
-import pytest
-from sqlmodel import Session
+from typing import Sequence
 
-from app.database import create_engine_and_session
-from app.models import Artifact, Link, Message, Schema, StructuredEntry
+import pytest
+import pytest_asyncio
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.database import create_async_engine_and_session
+from app.models import Artifact, Schema, StructuredEntry
 from app.repositories import (
     ArtifactRepository,
     LinkRepository,
+    MessageRepository,
     SchemaRepository,
     StructuredEntryRepository,
 )
 
 
-@pytest.fixture()
-def session():
-    engine, SessionLocal = create_engine_and_session(url="sqlite://")
-    Artifact.metadata.create_all(engine)
-    Schema.metadata.create_all(engine)
-    Message.metadata.create_all(engine)
-    StructuredEntry.metadata.create_all(engine)
-    Link.metadata.create_all(engine)
+class RecordingEmbeddingClient:
+    def __init__(self, *, vector: Sequence[float]) -> None:
+        self.vector = list(vector)
+        self.calls: list[Sequence[str]] = []
 
-    with SessionLocal() as session:
+    async def embed(self, texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        self.calls.append(tuple(texts))
+        return [list(self.vector) for _ in texts]
+
+
+@pytest_asyncio.fixture()
+async def session() -> AsyncSession:
+    engine, session_factory = create_async_engine_and_session(url="sqlite+aiosqlite:///:memory:?cache=shared")
+    async with engine.begin() as connection:
+        await connection.run_sync(SQLModel.metadata.create_all)
+    async with session_factory() as session:
         yield session
+    await engine.dispose()
 
 
-def test_artifact_hierarchy(session: Session):
-    repo = ArtifactRepository(session)
+@pytest_asyncio.fixture()
+def embedding_client() -> RecordingEmbeddingClient:
+    return RecordingEmbeddingClient(vector=[0.1, 0.2, 0.3])
 
-    root = repo.create(title="Root", summary="", summary_vector=[0.1, 0.2])
-    child = repo.create_child(
-        parent=root,
-        title="Child",
-        summary="Child summary",
-        summary_vector=[0.2, 0.4],
-    )
 
-    fetched_root = repo.get(root.id)
+@pytest.mark.asyncio
+async def test_artifact_hierarchy(session: AsyncSession, embedding_client: RecordingEmbeddingClient) -> None:
+    repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+
+    root = await repo.create(title="Root", summary="Root summary")
+    child = await repo.create_child(parent=root, title="Child", summary="Child summary")
+
+    fetched_root = await repo.get_with_related(root.id)
     assert fetched_root is not None
     assert fetched_root.id == root.id
     assert fetched_root.children[0].id == child.id
     assert child.parent_artifact_id == root.id
+    assert embedding_client.calls == [("Root summary",), ("Child summary",)]
+    assert root.summary_vector is not None
+    assert child.summary_vector is not None
 
 
-def test_structured_entry_schema_linkage(session: Session):
-    artifact_repo = ArtifactRepository(session)
-    schema_repo = SchemaRepository(session)
-    entry_repo = StructuredEntryRepository(session)
+@pytest.mark.asyncio
+async def test_structured_entry_schema_linkage(
+    session: AsyncSession, embedding_client: RecordingEmbeddingClient
+) -> None:
+    artifact_repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+    schema_repo = SchemaRepository(session=session)
+    entry_repo = StructuredEntryRepository(session=session, embedding_client=embedding_client)
 
-    artifact = artifact_repo.create(title="Artifact", summary="", summary_vector=None)
-    schema = schema_repo.create(
+    artifact = await artifact_repo.create(title="Artifact", summary="Artifact summary")
+    schema = await schema_repo.create(
         name="Task Schema",
         description="Tracks tasks",
         schema_json={"Task": "string"},
         description_vector=[0.1, 0.3],
     )
     artifact.applied_schema_id = schema.id
-    session.commit()
+    await session.commit()
 
-    entry = entry_repo.create(
+    entry = await entry_repo.create(
         artifact=artifact,
         data_json={"Task": "Ship"},
         text_representation="Ship",
-        vector=[0.2, 0.5],
     )
 
-    refreshed = entry_repo.get(entry.id)
+    refreshed = await entry_repo.get(entry.id)
     assert refreshed is not None
     assert refreshed.artifact_id == artifact.id
-    assert refreshed.schema is None  # no direct relation but ensures ORM fields exist
+    assert refreshed.schema is None
     assert artifact.applied_schema_id == schema.id
+    assert embedding_client.calls[-1] == ("Ship",)
+    assert refreshed.text_representation_vector is not None
 
 
-def test_link_repository(session: Session):
-    artifact_repo = ArtifactRepository(session)
-    link_repo = LinkRepository(session)
+@pytest.mark.asyncio
+async def test_link_repository(session: AsyncSession) -> None:
+    artifact_repo = ArtifactRepository(session=session)
+    link_repo = LinkRepository(session=session)
 
-    source = artifact_repo.create(title="Source", summary="", summary_vector=None)
-    target = artifact_repo.create(title="Target", summary="", summary_vector=None)
+    source = await artifact_repo.create(title="Source", summary="")
+    target = await artifact_repo.create(title="Target", summary="")
 
-    link = link_repo.create(
+    link = await link_repo.create(
         source_type="artifact",
         source_id=source.id,
         target_type="artifact",
@@ -87,5 +108,62 @@ def test_link_repository(session: Session):
         description="Related artifacts",
     )
 
-    retrieved = link_repo.list_for_entity(entity_type="artifact", entity_id=source.id)
+    retrieved = await link_repo.list_for_entity(entity_type="artifact", entity_id=source.id)
     assert retrieved == [link]
+
+
+@pytest.mark.asyncio
+async def test_artifact_update_recalculates_vector(
+    session: AsyncSession, embedding_client: RecordingEmbeddingClient
+) -> None:
+    repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+    artifact = await repo.create(title="Original", summary="Initial summary")
+
+    embedding_client.vector = [0.9, 0.8, 0.7]
+    updated = await repo.update_summary(artifact=artifact, summary="Updated summary")
+
+    assert updated.summary == "Updated summary"
+    assert updated.summary_vector == [0.9, 0.8, 0.7]
+    assert embedding_client.calls[-1] == ("Updated summary",)
+
+
+@pytest.mark.asyncio
+async def test_message_update_recalculates_vector(
+    session: AsyncSession, embedding_client: RecordingEmbeddingClient
+) -> None:
+    artifact_repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+    message_repo = MessageRepository(session=session, embedding_client=embedding_client)
+    artifact = await artifact_repo.create(title="Artifact", summary="Summary")
+    message = await message_repo.create(artifact=artifact, content="Old", sender="user")
+
+    embedding_client.vector = [0.4, 0.4, 0.4]
+    updated = await message_repo.update_content(message=message, content="New content")
+
+    assert updated.content == "New content"
+    assert updated.content_vector == [0.4, 0.4, 0.4]
+    assert embedding_client.calls[-1] == ("New content",)
+
+
+@pytest.mark.asyncio
+async def test_structured_entry_update_recalculates_vector(
+    session: AsyncSession, embedding_client: RecordingEmbeddingClient
+) -> None:
+    artifact_repo = ArtifactRepository(session=session, embedding_client=embedding_client)
+    entry_repo = StructuredEntryRepository(session=session, embedding_client=embedding_client)
+    artifact = await artifact_repo.create(title="Artifact", summary="Summary")
+    entry = await entry_repo.create(
+        artifact=artifact,
+        data_json={"Task": "Ship"},
+        text_representation="Ship",
+    )
+
+    embedding_client.vector = [0.6, 0.6, 0.6]
+    updated = await entry_repo.update_text_representation(
+        entry=entry,
+        text_representation="Ship updated",
+        data_json={"Task": "Ship", "Status": "Done"},
+    )
+
+    assert updated.text_representation == "Ship updated"
+    assert updated.text_representation_vector == [0.6, 0.6, 0.6]
+    assert embedding_client.calls[-1] == ("Ship updated",)


### PR DESCRIPTION
## Summary
- add shared FastAPI dependencies and async session handling so services receive AsyncSession and embedding clients via DI【F:backend/app/api/dependencies.py†L1-L40】【F:backend/app/api/session.py†L1-L29】
- implement PGVectorIndex with entity filtering and distance strategies, plus refactor ContextNavigator to consume the new SearchHit and DistanceStrategy types【F:backend/app/services/vector_index.py†L1-L197】【F:backend/app/services/context_navigator.py†L1-L103】【F:backend/app/services/search_types.py†L1-L26】
- migrate repositories and API routes to async/await with automatic embedding recalculation, update migration to use HNSW indexes, and expand tests for async flows and embedding coverage【F:backend/app/repositories.py†L1-L266】【F:backend/app/api/routes.py†L1-L210】【F:backend/alembic/versions/20240101_000001_initial.py†L122-L177】【F:backend/tests/test_api.py†L1-L192】【F:backend/tests/test_repositories.py†L1-L164】【F:backend/tests/services/test_vector_index.py†L1-L92】

## Testing
- pytest tests/services/test_vector_index.py tests/test_repositories.py tests/test_api.py【827491†L1-L24】

------
https://chatgpt.com/codex/tasks/task_e_68dd471b85608328b5348713d29ebc3b