### PR TITLE
Ensure frontend bootstrap loads global styles

### DIFF
--- a/frontend/src/main.test.tsx
+++ b/frontend/src/main.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('main bootstrap', () => {
+  it('imports global styles before rendering the app', async () => {
+    vi.resetModules();
+    document.body.innerHTML = '<div id="root"></div>';
+
+    const routerMock = Symbol('router');
+
+    vi.doMock('./routes', () => ({
+      createAppRouter: vi.fn(() => routerMock),
+    }));
+
+    vi.doMock('react-router-dom', () => ({
+      RouterProvider: ({ router }: { router: unknown }) => <div data-router={String(router)} />,
+    }));
+
+    vi.doMock('./providers/AppProviders', () => ({
+      AppProviders: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    }));
+
+    let mainStylesImported = 0;
+
+    vi.doMock('./styles/index.css', () => {
+      mainStylesImported += 1;
+      return {};
+    });
+
+    const renderMock = vi.fn();
+    const createRootMock = vi.fn(() => ({ render: renderMock }));
+
+    vi.doMock('react-dom/client', () => ({
+      default: {
+        createRoot: createRootMock,
+      },
+    }));
+
+    await import('./main');
+
+    expect(mainStylesImported).toBeGreaterThan(0);
+    expect(createRootMock).toHaveBeenCalledWith(document.getElementById('root'));
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 import { AppProviders } from './providers/AppProviders';
 import { createAppRouter } from './routes';
+import './styles/index.css';
 
 const router = createAppRouter();
 

--- a/frontend/src/store/workspaceStore.test.ts
+++ b/frontend/src/store/workspaceStore.test.ts
@@ -10,7 +10,7 @@ const mockFetch = (payload: unknown) => {
       get: () => 'application/json',
     },
     json: async () => payload,
-  } as Partial<Response>;
+  } as unknown as Partial<Response>;
   const fetchMock = vi.fn().mockResolvedValue(response);
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- import the global stylesheet from the frontend entry point so builds include Mantine styles
- add a Vitest bootstrap test that verifies the router is rendered after the styles are loaded
- fix TypeScript setup to recognize Vite globals and quiet an existing test helper cast warning

## Testing
- npm run test -- --run
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd4f8ecb5c832888f315b3dd08c1c8